### PR TITLE
fix: ensure statistics widget returns string value

### DIFF
--- a/src/Admin/DashboardWidgets/Statistics.php
+++ b/src/Admin/DashboardWidgets/Statistics.php
@@ -117,6 +117,6 @@ class Statistics extends BaseDashboardWidget
             $query->whereBetween('created_at', [$start, $end]);
         });
 
-        return empty($count) ? 0 : $count;
+        return (string) (empty($count) ? 0 : $count);
     }
 }


### PR DESCRIPTION
The getValue method in Statistics widget now explicitly casts the count to string,
preventing potential type mismatches when displaying dashboard statistics.