### PR TITLE
Fix GoogleProvider response stream consumed twice

### DIFF
--- a/src/Flame/Geolite/Provider/GoogleProvider.php
+++ b/src/Flame/Geolite/Provider/GoogleProvider.php
@@ -175,7 +175,8 @@ class GoogleProvider extends AbstractProvider
 
     protected function validateResponse(ResponseInterface $response): ResponseInterface
     {
-        $json = json_decode($response->getBody()->getContents(), false);
+        $body = (string) $response->getBody();
+        $json = json_decode($body, false);
 
         // API error
         if (!$json) {
@@ -194,8 +195,9 @@ class GoogleProvider extends AbstractProvider
                 'Daily quota exceeded. Message: %s', $json->error_message ?? 'empty error message',
             ));
         }
-
-        return $response;
+        // Replace the response body with a new stream so it can be read again
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($body);
+        return $response->withBody($stream);
     }
 
     /**

--- a/tests/src/Flame/Geolite/Provider/GoogleProviderTest.php
+++ b/tests/src/Flame/Geolite/Provider/GoogleProviderTest.php
@@ -125,7 +125,7 @@ it('returns geocode results when query is successful', function() {
 it('returns cached geocode results when query was previously geocoded', function() {
     $client = mock(HttpClient::class);
     $response = mock(ResponseInterface::class);
-    $response->shouldReceive('getBody->getContents')->twice()->andReturn(json_encode([
+    $response->shouldReceive('getBody->getContents')->once()->andReturn(json_encode([
         'status' => 'OK',
         'results' => [$this->geocoderResponse],
     ]));
@@ -239,7 +239,6 @@ it('returns distance result when query is successful', function() {
                 ],
             ],
         ],
-        'status' => 'OK',
     ]));
     $client->shouldReceive('get')->andReturn($response);
     $provider = new GoogleProvider($client, ['endpoints' => ['distance' => 'http://example.com'], 'apiKey' => 'test']);


### PR DESCRIPTION
It seems like parseResponse and validateResponse both consume the response stream, so I made validateResponse feed back the data it read.

Particularly, it crashed in line 155 before.