### PR TITLE
Fix zero-decimal currency formatting

### DIFF
--- a/src/System/Models/Currency.php
+++ b/src/System/Models/Currency.php
@@ -166,8 +166,11 @@ class Currency extends Model implements CurrencyInterface
     #[Override]
     public function getFormat(): string
     {
-        $format = ($this->thousand_sign ?: '!').'0'.$this->decimal_sign;
-        $format .= str_repeat('0', (int)$this->decimal_position);
+        $format = ($this->thousand_sign ?: '!').'0';
+
+        if ((int)$this->decimal_position > 0) {
+            $format .= $this->decimal_sign.str_repeat('0', (int)$this->decimal_position);
+        }
 
         return $this->getSymbolPosition() ? '1'.$format.$this->getSymbol() : $this->getSymbol().'1'.$format;
     }

--- a/tests/src/Flame/Currency/CurrencyTest.php
+++ b/tests/src/Flame/Currency/CurrencyTest.php
@@ -59,6 +59,22 @@ it('formats value to currency string when thousand sign is missing', function() 
     expect(resolve(Currency::class)->format(1234.56, 'ABC'))->toBe('£1234.56');
 });
 
+it('formats value to currency string for zero-decimal currencies', function() {
+    CurrencyModel::factory()->create([
+        'currency_code' => 'VND',
+        'currency_symbol' => 'd',
+        'currency_rate' => 1.0,
+        'currency_status' => 1,
+        'symbol_position' => false,
+        'thousand_sign' => ',',
+        'decimal_sign' => '.',
+        'decimal_position' => 0,
+    ]);
+
+    expect(resolve(Currency::class)->format(1234.56, 'VND'))->toBe('d1,235')
+        ->and(resolve(Currency::class)->format(-1234.56, 'VND'))->toBe('-d1,235');
+});
+
 it('returns null for invalid to currency rate', function() {
     CurrencyModel::factory()->create([
         'currency_code' => 'ABC',

--- a/tests/src/System/Models/CurrencyTest.php
+++ b/tests/src/System/Models/CurrencyTest.php
@@ -81,6 +81,18 @@ it('returns correct currency format with symbol at the beginning', function() {
     expect($currency->getFormat())->toBe('$1,0.00');
 });
 
+it('returns correct currency format for zero-decimal currencies', function() {
+    $currency = new Currency([
+        'currency_symbol' => 'd',
+        'symbol_position' => false,
+        'thousand_sign' => ',',
+        'decimal_sign' => '.',
+        'decimal_position' => 0,
+    ]);
+
+    expect($currency->getFormat())->toBe('d1,0');
+});
+
 it('configures model correctly', function() {
     $currency = new Currency;
 


### PR DESCRIPTION
## Summary

This fixes formatting for zero-decimal currencies such as VND.

When `decimal_position` is `0`, the currency format should not include a decimal separator. The previous logic always appended the decimal sign, which could lead to invalid formatting assumptions downstream.

## Changes

- omit the decimal separator when `decimal_position` is `0`
- add regression tests for zero-decimal currency formatting

## Verification

- added test coverage for `decimal_position = 0`
- manually sanity-checked the formatting path for a VND-like currency

## Notes

I could not run the full test suite locally because the project test setup expects a DB driver that is not available in my current environment.