### PR TITLE
Add support for currency without decimals

### DIFF
--- a/src/Flame/Currency/Currency.php
+++ b/src/Flame/Currency/Currency.php
@@ -112,7 +112,8 @@ class Currency
         $valFormat = array_get($valFormat, 0, 0);
 
         // Count decimals length
-        $decimals = $decimal ? strlen(substr(strrchr((string)$valFormat, (string)$decimal), 1)) : 0;
+        $strrchrResult = $decimal ? strrchr((string)$valFormat, (string)$decimal) : false;
+        $decimals = $strrchrResult !== false ? strlen(substr($strrchrResult, 1)) : 0;
 
         // Do we have a negative value?
         $negative = $value < 0 ? '-' : '';

--- a/src/System/Models/Currency.php
+++ b/src/System/Models/Currency.php
@@ -166,8 +166,11 @@ class Currency extends Model implements CurrencyInterface
     #[Override]
     public function getFormat(): string
     {
-        $format = ($this->thousand_sign ?: '!').'0'.$this->decimal_sign;
-        $format .= str_repeat('0', (int)$this->decimal_position);
+        $format = ($this->thousand_sign ?: '!').'0';
+        if ((int)$this->decimal_position > 0) {
+            $format .= $this->decimal_sign;
+            $format .= str_repeat('0', (int)$this->decimal_position);
+        }
 
         return $this->getSymbolPosition() ? '1'.$format.$this->getSymbol() : $this->getSymbol().'1'.$format;
     }


### PR DESCRIPTION
This pull request addresses improvements and bug fixes related to currency formatting in the codebase. The main focus is on ensuring correct handling of decimal places and formatting logic when generating currency strings.

**Currency formatting improvements:**

* Refactored the decimal count logic in `Currency.php` to avoid errors when the decimal separator is not present, ensuring robust handling of currency values without decimals.
* Updated the `getFormat` method in `Currency.php` to only append the decimal sign and zeros if the currency actually uses decimal places, preventing incorrect format strings for currencies without decimals.