### PR TITLE
Release v4.2.2

### DIFF
--- a/config/currency.php
+++ b/config/currency.php
@@ -1,5 +1,10 @@
 <?php
 
+use Igniter\Flame\Currency\Converters\FixerIO;
+use Igniter\Flame\Currency\Converters\OpenExchangeRates;
+use Igniter\Flame\Currency\Formatters\PHPIntl;
+use Igniter\System\Models\Currency;
+
 return [
 
     /*
@@ -36,12 +41,12 @@ return [
     'converters' => [
 
         'fixerio' => [
-            'class' => \Igniter\Flame\Currency\Converters\FixerIO::class,
+            'class' => FixerIO::class,
             'apiKey' => '',
         ],
 
         'openexchangerates' => [
-            'class' => \Igniter\Flame\Currency\Converters\OpenExchangeRates::class,
+            'class' => OpenExchangeRates::class,
             'apiKey' => '',
         ],
 
@@ -56,7 +61,7 @@ return [
     |
     */
 
-    'model' => \Igniter\System\Models\Currency::class,
+    'model' => Currency::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -114,7 +119,7 @@ return [
     'formatters' => [
 
         'php_intl' => [
-            'class' => \Igniter\Flame\Currency\Formatters\PHPIntl::class,
+            'class' => PHPIntl::class,
         ],
 
     ],

--- a/database/migrations/admin/2022_06_30_010000_drop_foreign_key_constraints_on_all_tables.php
+++ b/database/migrations/admin/2022_06_30_010000_drop_foreign_key_constraints_on_all_tables.php
@@ -32,7 +32,7 @@ return new class extends Migration
                 $table->dropForeignKeyIfExists($foreignKey);
                 $table->dropIndexIfExists(sprintf('%s_%s_foreign', $tableName, $foreignKey));
             });
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             Log::error($ex);
         }
     }

--- a/database/migrations/system/2018_06_12_000300_rename_model_class_names_to_morph_map_custom_names.php
+++ b/database/migrations/system/2018_06_12_000300_rename_model_class_names_to_morph_map_custom_names.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ return new class extends Migration
 
     public function up()
     {
-        $morphMap = \Illuminate\Database\Eloquent\Relations\Relation::$morphMap;
+        $morphMap = Relation::$morphMap;
         $this->morphMap = array_flip($morphMap);
 
         $this->updateMorphClassName([

--- a/database/migrations/system/2018_10_19_000300_create_media_attachments_table.php
+++ b/database/migrations/system/2018_10_19_000300_create_media_attachments_table.php
@@ -82,7 +82,7 @@ return new class extends Migration
 
             $media->save();
             $model->media()->save($media);
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             Log::debug($ex);
         }
     }

--- a/database/migrations/system/2022_06_30_010000_drop_foreign_key_constraints_on_all_tables.php
+++ b/database/migrations/system/2022_06_30_010000_drop_foreign_key_constraints_on_all_tables.php
@@ -32,7 +32,7 @@ return new class extends Migration
                 $table->dropForeignKeyIfExists($foreignKey);
                 $table->dropIndexIfExists(sprintf('%s_%s_foreign', $tableName, $foreignKey));
             });
-        } catch (\Exception $ex) {
+        } catch (Exception $ex) {
             Log::error($ex);
         }
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -811,6 +811,30 @@ parameters:
 			path: src/Flame/Providers/EventServiceProvider.php
 
 		-
+			message: '#^Method Igniter\\Flame\\Scaffold\\Console\\MakeComponent\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Overwrite existing…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Flame/Scaffold/Console/MakeComponent.php
+
+		-
+			message: '#^Method Igniter\\Flame\\Scaffold\\Console\\MakeController\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Overwrite existing…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Flame/Scaffold/Console/MakeController.php
+
+		-
+			message: '#^Method Igniter\\Flame\\Scaffold\\Console\\MakeExtension\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Overwrite existing…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Flame/Scaffold/Console/MakeExtension.php
+
+		-
+			message: '#^Method Igniter\\Flame\\Scaffold\\Console\\MakeModel\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Overwrite existing…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Flame/Scaffold/Console/MakeModel.php
+
+		-
 			message: '#^Igniter\\Flame\\Support\\Extendable\:\:extendableCall\(\) calls parent\:\:__call\(\) but Igniter\\Flame\\Support\\Extendable does not extend any class\.$#'
 			identifier: class.noParent
 			count: 1
@@ -843,6 +867,12 @@ parameters:
 		-
 			message: '#^Call to an undefined static method Illuminate\\Support\\Str\:\:normalizeClassName\(\)\.$#'
 			identifier: staticMethod.notFound
+			count: 1
+			path: src/Flame/Support/Helpers/helpers.php
+
+		-
+			message: '#^Parameter \#1 \$message of static method Illuminate\\Log\\Logger\:\:error\(\) expects array\|Illuminate\\Contracts\\Support\\Arrayable\|Illuminate\\Contracts\\Support\\Jsonable\|Illuminate\\Support\\Stringable\|string, Exception given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Flame/Support/Helpers/helpers.php
 
@@ -971,6 +1001,72 @@ parameters:
 			identifier: staticMethod.notFound
 			count: 1
 			path: src/System/Classes/Controller.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\ExtensionRefresh\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''pretend'', null, 1, ''Dump the SQL…''\}, array\{''step'', null, 4, ''The number of…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/ExtensionRefresh.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\ExtensionRemove\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Force remove\.''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/ExtensionRemove.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\IgniterDown\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''database'', null, 4, ''The database…''\}, array\{''force'', null, 1, ''Force the operation…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/IgniterDown.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\IgniterInstall\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Force the operation…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/IgniterInstall.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\IgniterPackageDiscover\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Force the operation…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/IgniterPackageDiscover.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\IgniterUp\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''database'', null, 4, ''The database…''\}, array\{''force'', null, 1, ''Force the operation…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/IgniterUp.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\IgniterUpdate\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Force updates\.''\}, array\{''check'', null, 1, ''Run update checks…''\}, array\{''core'', null, 1, ''Update core…''\}, array\{''addons'', null, 12, ''Update specified…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/IgniterUpdate.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\IgniterUtil\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''admin'', null, 1, ''Compile admin…''\}, array\{''minify'', null, 2, ''Whether to minify…''\}, array\{''carteKey'', null, 2, ''Specify a carteKey…''\}, array\{''theme'', null, 2, ''Specify a theme…''\}, array\{''extensions'', null, 1, ''Set the version…''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/IgniterUtil.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\ThemePublish\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''existing'', null, 1, ''Publish and…''\}, array\{''force'', null, 1, ''Force publish\.''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/ThemePublish.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\ThemeRemove\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''force'', null, 1, ''Force remove\.''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/ThemeRemove.php
+
+		-
+			message: '#^Method Igniter\\System\\Console\\Commands\\ThemeVendorPublish\:\:getOptions\(\) should return array\<array\{0\: non\-empty\-string, 1\?\: non\-empty\-array\<string\>\|string, 2\?\: int\<0, 31\>, 3\?\: string, 4\?\: mixed, 5\?\: \(Closure\(Symfony\\Component\\Console\\Completion\\CompletionInput, Symfony\\Component\\Console\\Completion\\CompletionSuggestions\)\: list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\)\|list\<string\|Symfony\\Component\\Console\\Completion\\Suggestion\>\}\|Symfony\\Component\\Console\\Input\\InputOption\> but returns array\{array\{''existing'', null, 1, ''Publish and…''\}, array\{''all'', null, 1, ''Publish assets for…''\}, array\{''theme'', null, 10, ''One or many theme…'', array\{\}\}, array\{''force'', null, 1, ''Force publish\.''\}\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/Console/Commands/ThemeVendorPublish.php
 
 		-
 			message: '#^Call to an undefined method Igniter\\Flame\\Database\\Builder\:\:sorted\(\)\.$#'

--- a/resources/lang/en/system.php
+++ b/resources/lang/en/system.php
@@ -625,6 +625,8 @@ return [
         'button_recommended_theme' => 'Install a recommended theme...',
         'button_install' => 'Install Selected...',
 
+        'error_meta_package' => 'The package is not compatible with this TastyIgniter version.',
+
         'help_carte_key' => 'A Carte key is required to add and update item from the TastyIgniter Marketplace. <br>Get one by creating a site from your <a href="https://tastyigniter.com/signin" target="_blank">TastyIgniter Account</a>, if you haven\'t already. For more information, see the <a href="https://tastyigniter.com/support/articles/carte-key" target="_blank">Carté Key Guide</a>',
         'alert_item_to_ignore' => 'Select item(s) to ignore.',
         'alert_item_to_update' => 'Select item(s) to update.',

--- a/resources/models/system/generalsettings.php
+++ b/resources/models/system/generalsettings.php
@@ -1,5 +1,7 @@
 <?php
 
+use Igniter\System\Models\Currency;
+
 return [
     'form' => [
         'toolbar' => [
@@ -96,7 +98,7 @@ return [
                     'tab' => 'lang:igniter::system.settings.text_tab_site',
                     'type' => 'radiotoggle',
                     'default' => 'openexchangerates',
-                    'options' => [\Igniter\System\Models\Currency::class, 'getConverterDropdownOptions'],
+                    'options' => [Currency::class, 'getConverterDropdownOptions'],
                 ],
                 'currency_converter[oer][apiKey]' => [
                     'label' => 'lang:igniter::system.settings.label_currency_converter_oer_api_key',

--- a/resources/views/admin/_partials/widgets/form/field_checkboxlist.blade.php
+++ b/resources/views/admin/_partials/widgets/form/field_checkboxlist.blade.php
@@ -7,6 +7,7 @@
 @if($this->previewMode && $field->value)
 
     <div class="field-checkboxlist">
+        <input type="hidden" name="{{ $field->getName() }}" value="" />
         @foreach($fieldOptions as $value => $option)
             @php
                 $checkboxId = 'checkbox_'.$field->getId().'_'.$loop->iteration;
@@ -49,7 +50,7 @@
                     <input
                         type="hidden"
                         name="{{ $field->getName() }}"
-                        value="0" />
+                        value="" />
 
                     @foreach($fieldOptions as $value => $option)
                         @php

--- a/src/Admin/Classes/AdminController.php
+++ b/src/Admin/Classes/AdminController.php
@@ -300,15 +300,15 @@ class AdminController extends Controller
 
             throw new AjaxException($response);
         } catch (MassAssignmentException $ex) {
-            throw new FlashException(lang('igniter::admin.form.mass_assignment_failed', ['attribute' => $ex->getMessage()]));
+            throw new FlashException(lang('igniter::admin.form.mass_assignment_failed', ['attribute' => $ex->getMessage()]), 'danger', $ex->getCode(), $ex);
         }
     }
 
     protected function getRequiredPermissionsForAction(string $actionToCheck): array
     {
-        return collect((array)$this->requiredPermissions)
+        return collect((array) $this->requiredPermissions)
             ->map(fn($permission, $action): ?array => (!is_string($action) || $action === '*' || $action === $actionToCheck)
-                ? (array)$permission : null)
+                ? (array) $permission : null)
             ->filter()
             ->collapse()
             ->all();

--- a/src/Admin/Classes/BaseWidget.php
+++ b/src/Admin/Classes/BaseWidget.php
@@ -116,7 +116,7 @@ class BaseWidget extends Extendable
      */
     protected function fillFromConfig(?array $properties = null)
     {
-        $properties = is_null($properties) ? array_keys((array)$this->config) : $properties;
+        $properties ??= array_keys((array)$this->config);
 
         foreach ($properties as $property) {
             if (property_exists($this, $property)) {

--- a/src/Admin/Classes/MainMenuItem.php
+++ b/src/Admin/Classes/MainMenuItem.php
@@ -152,7 +152,7 @@ class MainMenuItem
      */
     public function displayAs($type, array $config = []): static
     {
-        $this->type = !is_null($type) ? $type : $this->type;
+        $this->type = $type ?? $this->type;
         $this->config = $this->evalConfig($config);
 
         return $this;

--- a/src/Admin/Classes/Navigation.php
+++ b/src/Admin/Classes/Navigation.php
@@ -43,7 +43,7 @@ class Navigation
     public function setContext(string $itemCode, ?string $parentCode = null): void
     {
         $this->navContextItemCode = $itemCode;
-        $this->navContextParentCode = is_null($parentCode) ? $itemCode : $parentCode;
+        $this->navContextParentCode = $parentCode ?? $itemCode;
     }
 
     public function getNavItems(): array

--- a/src/Admin/Facades/AdminMenu.php
+++ b/src/Admin/Facades/AdminMenu.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Igniter\Admin\Facades;
 
 use Igniter\Admin\Classes\Navigation;
+use Igniter\User\Auth\UserGuard;
 use Illuminate\Support\Facades\Facade;
 use Override;
 
@@ -42,14 +43,14 @@ use Override;
  * @method static string compileFileContent(string $filePath)
  * @method static string makeViewContent(string $view, array $data = [])
  *
- * @see \Igniter\Admin\Classes\Navigation
+ * @see Navigation
  */
 class AdminMenu extends Facade
 {
     /**
      * Get the registered name of the component.
      *
-     * @see \Igniter\User\Auth\UserGuard
+     * @see UserGuard
      */
     #[Override]
     protected static function getFacadeAccessor(): string

--- a/src/Admin/Helpers/AdminHelper.php
+++ b/src/Admin/Helpers/AdminHelper.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\URL;
 
 /**
  * Admin Helper
- * @see \Igniter\Admin\Helpers\AdminHelper
+ * @see AdminHelper
  */
 class AdminHelper
 {

--- a/src/Admin/Http/Actions/FormController.php
+++ b/src/Admin/Http/Actions/FormController.php
@@ -385,7 +385,7 @@ class FormController extends ControllerAction
     {
         $redirectContext = explode('-', (string)$context, 2)[0];
         $redirectAction = explode('-', (string)$context, 2)[1] ?? '';
-        $redirectSource = in_array($redirectAction, ['new', 'close'])
+        $redirectSource = in_array($redirectAction, ['new', 'close'], true)
             ? 'redirect'.studly_case($redirectAction)
             : 'redirect';
 

--- a/src/Admin/ServiceProvider.php
+++ b/src/Admin/ServiceProvider.php
@@ -91,7 +91,7 @@ class ServiceProvider extends AppServiceProvider
 
         foreach ([
             'AdminMenu' => AdminMenu::class,
-            'Template' => \Igniter\Admin\Facades\Template::class,
+            'Template' => Facades\Template::class,
         ] as $alias => $class) {
             $loader->alias($alias, $class);
         }

--- a/src/Admin/Traits/ControllerUtils.php
+++ b/src/Admin/Traits/ControllerUtils.php
@@ -46,7 +46,7 @@ trait ControllerUtils
             return false;
         }
 
-        throw_if(in_array(strtolower($action), array_map('strtolower', $this->hiddenActions)),
+        throw_if(in_array(strtolower($action), array_map('strtolower', $this->hiddenActions), true),
             new FlashException(sprintf('Method [%s] is not allowed in the controller [%s]', $action, $this::class)),
         );
 

--- a/src/Admin/Widgets/Lists.php
+++ b/src/Admin/Widgets/Lists.php
@@ -303,15 +303,15 @@ class Lists extends BaseWidget
                 // Manipulate a count query for the sub query
                 $countQuery = $relationObj->getRelationExistenceCountQuery($relationObj->getRelated()->newQueryWithoutScopes(), $query);
 
-                $joinSql = Db::raw($this->isColumnRelated($column, true) ? 'group_concat('.$sqlSelect." separator ', ')" : $sqlSelect);
+                $joinSql = DB::raw($this->isColumnRelated($column, true) ? 'group_concat('.$sqlSelect." separator ', ')" : $sqlSelect);
 
                 $joinSql = $countQuery->select($joinSql)->toRawSql();
 
-                $selects[] = Db::raw('('.$joinSql.') as '.$alias);
+                $selects[] = DB::raw('('.$joinSql.') as '.$alias);
             } // Primary column
             else {
                 $sqlSelect = $this->parseTableName($column->sqlSelect, $primaryTable);
-                $selects[] = Db::raw($sqlSelect.' as '.$alias);
+                $selects[] = DB::raw($sqlSelect.' as '.$alias);
             }
         }
 
@@ -1026,7 +1026,7 @@ class Lists extends BaseWidget
     protected function getSetupPerPageOptions(): array
     {
         $perPageOptions = [20, 40, 80, 100, 120];
-        if (!in_array($this->pageLimit, $perPageOptions)) {
+        if (!in_array($this->pageLimit, $perPageOptions, true)) {
             $perPageOptions[] = $this->pageLimit;
         }
 
@@ -1188,7 +1188,8 @@ class Lists extends BaseWidget
             'morphMany',
             'attachMany',
             'hasManyThrough',
-        ]);
+        ],
+            true);
     }
 
     /**

--- a/src/Flame/Composer/Manager.php
+++ b/src/Flame/Composer/Manager.php
@@ -269,6 +269,12 @@ class Manager
 
     protected function getProcess(array $command, array $env = []): Process
     {
+        // Ensure COMPOSER_HOME is set to ensure composer runs correctly in environments
+        // where the global composer installation is not available or configured properly.
+        if (!isset($env['COMPOSER_HOME']) && !getenv('COMPOSER_HOME')) {
+            $env['COMPOSER_HOME'] = $this->storagePath;
+        }
+
         return (new Process($command, $this->workingPath, $env))->setTimeout(null);
     }
 

--- a/src/Flame/Currency/Currency.php
+++ b/src/Flame/Currency/Currency.php
@@ -112,7 +112,8 @@ class Currency
         $valFormat = array_get($valFormat, 0, 0);
 
         // Count decimals length
-        $decimals = $decimal ? strlen(substr(strrchr((string)$valFormat, (string)$decimal), 1)) : 0;
+        $strrchrResult = $decimal ? strrchr((string)$valFormat, (string)$decimal) : false;
+        $decimals = $strrchrResult !== false ? strlen(substr($strrchrResult, 1)) : 0;
 
         // Do we have a negative value?
         $negative = $value < 0 ? '-' : '';

--- a/src/Flame/Database/Attach/Manipulator.php
+++ b/src/Flame/Database/Attach/Manipulator.php
@@ -42,7 +42,7 @@ class Manipulator
 
     public function useDriver(string $driver): self
     {
-        if (!in_array($driver, ['gd', 'imagick'])) {
+        if (!in_array($driver, ['gd', 'imagick'], true)) {
             throw new LogicException(sprintf("Driver must be 'gd' or 'imagick'. '%s' provided.", $driver));
         }
 
@@ -110,7 +110,7 @@ class Manipulator
         }
 
         if ($this->driver === 'gd') {
-            return in_array($extension, $gdExtensions);
+            return in_array($extension, $gdExtensions, true);
         }
 
         return in_array($extension, $imagickExtensions);

--- a/src/Flame/Database/Attach/MediaAdder.php
+++ b/src/Flame/Database/Attach/MediaAdder.php
@@ -71,7 +71,7 @@ class MediaAdder
 
         $media->name = $media->getUniqueName();
         $media->disk = $this->diskName ?? $media->getDiskName();
-        $media->tag = $this->tag ?? $this->performedOn->getDefaultTagName();
+        $media->tag = $this->performedOn->getDefaultTagName() ?? $this->tag;
         $media->custom_properties = $this->customProperties;
 
         $this->attachMedia($media);

--- a/src/Flame/Database/Concerns/ExtendsEloquentBuilder.php
+++ b/src/Flame/Database/Concerns/ExtendsEloquentBuilder.php
@@ -38,7 +38,7 @@ trait ExtendsEloquentBuilder
      */
     public function dropdown($column, $key = null)
     {
-        $key = !is_null($key) ? $key : $this->model->getKeyName();
+        $key ??= $this->model->getKeyName();
 
         return $this->lists($column, $key);
     }

--- a/src/Flame/Database/Model.php
+++ b/src/Flame/Database/Model.php
@@ -74,7 +74,7 @@ abstract class Model extends EloquentModel
      *
      * @param array $attributes
      *
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return EloquentModel|static
      */
     public static function make($attributes = [])
     {
@@ -83,7 +83,7 @@ abstract class Model extends EloquentModel
 
     /**
      * Reloads the model attributes from the database.
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return EloquentModel|static
      */
     public function reload()
     {
@@ -179,7 +179,7 @@ abstract class Model extends EloquentModel
      *
      * @param array $attributes
      *
-     * @return \Illuminate\Database\Eloquent\Model|static
+     * @return EloquentModel|static
      */
     #[Override]
     public function newFromBuilder($attributes = [], $connection = null)

--- a/src/Flame/Database/Pivot.php
+++ b/src/Flame/Database/Pivot.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\Concerns\AsPivot;
  * @method static Builder<static>|Pivot newModelQuery()
  * @method static Builder<static>|Pivot newQuery()
  * @method static Builder<static>|Pivot query()
- * @mixin \Illuminate\Database\Eloquent\Model
+ * @mixin ModelBase
  */
 class Pivot extends Model
 {

--- a/src/Flame/Flash/Facades/Flash.php
+++ b/src/Flame/Flash/Facades/Flash.php
@@ -28,14 +28,14 @@ use Override;
  * @method static FlashBag important()
  * @method static FlashBag clear()
  *
- * @see \Igniter\Flame\Flash\FlashBag
+ * @see FlashBag
  */
 class Flash extends IlluminateFacade
 {
     /**
      * Get the registered name of the component.
      *
-     * @see \Igniter\Flame\Flash\FlashBag
+     * @see FlashBag
      */
     #[Override]
     protected static function getFacadeAccessor(): string

--- a/src/Flame/Geolite/Contracts/AbstractProvider.php
+++ b/src/Flame/Geolite/Contracts/AbstractProvider.php
@@ -87,7 +87,7 @@ abstract class AbstractProvider
     {
         $lifetime = config('igniter-geocoder.cache.duration');
 
-        return !is_null($this->cacheLifetime) ? $this->cacheLifetime : $lifetime;
+        return $this->cacheLifetime ?? $lifetime;
     }
 
     protected function cacheCallback(string $cacheKey, Closure $closure): mixed

--- a/src/Flame/Geolite/Polygon.php
+++ b/src/Flame/Geolite/Polygon.php
@@ -31,7 +31,7 @@ class Polygon implements ArrayAccess, Countable, IteratorAggregate, JsonSerializ
     protected ?int $precision = 8;
 
     /**
-     * @param null|array|Model\CoordinatesCollection $coordinates
+     * @param null|array|CoordinatesCollection $coordinates
      */
     public function __construct($coordinates = null)
     {

--- a/src/Flame/Html/FormFacade.php
+++ b/src/Flame/Html/FormFacade.php
@@ -26,7 +26,7 @@ use Override;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Igniter\Flame\Html\FormBuilder
+ * @see FormBuilder
  */
 class FormFacade extends Facade
 {

--- a/src/Flame/Html/HtmlFacade.php
+++ b/src/Flame/Html/HtmlFacade.php
@@ -10,7 +10,7 @@ use Override;
 /**
  * @method static string attributes(array $attributes)
  *
- * @see \Igniter\Flame\Html\HtmlBuilder
+ * @see HtmlBuilder
  */
 class HtmlFacade extends Facade
 {

--- a/src/Flame/Pagic/Concerns/HasAttributes.php
+++ b/src/Flame/Pagic/Concerns/HasAttributes.php
@@ -413,7 +413,7 @@ trait HasAttributes
             'mTime',
             'code',
             'settings',
-        ]);
+        ], true);
     }
 
     /**

--- a/src/Flame/Pagic/Finder.php
+++ b/src/Flame/Pagic/Finder.php
@@ -277,7 +277,7 @@ class Finder
      */
     public function getFresh(array $columns = ['*']): ?array
     {
-        $this->columns ??= $columns;
+        $this->columns = $columns;
 
         $processCmd = $this->select ? 'processSelect' : 'processSelectAll';
 
@@ -460,7 +460,7 @@ class Finder
      */
     public function getCached(array $columns = ['*']): array
     {
-        $this->columns ??= $columns;
+        $this->columns = $columns;
 
         $key = $this->getCacheKey();
 

--- a/src/Flame/Support/Facades/File.php
+++ b/src/Flame/Support/Facades/File.php
@@ -81,14 +81,14 @@ use Symfony\Component\Finder\SplFileInfo;
  * @method static bool hasMacro(string $name)
  * @method static void flushMacros()
  *
- * @see \Igniter\Flame\Filesystem\Filesystem
+ * @see Filesystem
  */
 class File extends IlluminateFacade
 {
     /**
      * Get the registered name of the component.
      *
-     * @see \Igniter\Flame\Filesystem\Filesystem
+     * @see Filesystem
      */
     #[Override]
     protected static function getFacadeAccessor(): string

--- a/src/Flame/Support/Facades/Igniter.php
+++ b/src/Flame/Support/Facades/Igniter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Igniter\Flame\Support\Facades;
 
+use Igniter\Flame\Filesystem\Filesystem;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Facade;
 use Override;
@@ -48,7 +49,7 @@ class Igniter extends Facade
     /**
      * Get the registered name of the component.
      *
-     * @see \Igniter\Flame\Filesystem\Filesystem
+     * @see Filesystem
      */
     #[Override]
     protected static function getFacadeAccessor(): string

--- a/src/Flame/Support/Igniter.php
+++ b/src/Flame/Support/Igniter.php
@@ -13,7 +13,7 @@ use Illuminate\View\Factory;
 
 class Igniter
 {
-    protected const string VERSION = 'v4.2.1';
+    protected const string VERSION = 'v4.2.2';
 
     /**
      * The base path for extensions.

--- a/src/Main/Classes/Theme.php
+++ b/src/Main/Classes/Theme.php
@@ -106,7 +106,7 @@ class Theme
     public function getMetaPath(): string
     {
         if (is_null($this->metaPath)) {
-            foreach (['/_meta', '/meta'] as $metaPath) {
+            foreach (['/_meta', '/meta', $this->sourcePath.'/_meta', $this->sourcePath.'/meta'] as $metaPath) {
                 if (File::isDirectory($this->path.$metaPath)) {
                     $this->metaPath = $metaPath;
                 }

--- a/src/System/Actions/SettingsModel.php
+++ b/src/System/Actions/SettingsModel.php
@@ -209,7 +209,7 @@ class SettingsModel extends ModelAction
      */
     protected function isKeyAllowed(string $key): bool
     {
-        return in_array($key, ['id', 'item', 'data']) || $this->model->hasRelation($key);
+        return in_array($key, ['id', 'item', 'data'], true) || $this->model->hasRelation($key);
     }
 
     /**

--- a/src/System/Classes/BaseComponent.php
+++ b/src/System/Classes/BaseComponent.php
@@ -96,7 +96,7 @@ abstract class BaseComponent extends Extendable implements Stringable
 
     /**
      * Renders a requested partial in context of this component,
-     * @see \Igniter\Main\Classes\MainController::renderPartial for usage.
+     * @see MainController::renderPartial for usage.
      */
     public function renderPartial(): mixed
     {
@@ -167,7 +167,7 @@ abstract class BaseComponent extends Extendable implements Stringable
             $segment = input($name);
         }
 
-        return is_null($segment) ? $default : $segment;
+        return $segment ?? $default;
     }
 
     //

--- a/src/System/Classes/BaseController.php
+++ b/src/System/Classes/BaseController.php
@@ -86,7 +86,7 @@ class BaseController extends Extendable
             return false;
         }
 
-        if (in_array(strtolower((string)$action), array_map('strtolower', $this->hiddenActions))) {
+        if (in_array(strtolower((string)$action), array_map('strtolower', $this->hiddenActions), true)) {
             return false;
         }
 

--- a/src/System/Classes/ComponentManager.php
+++ b/src/System/Classes/ComponentManager.php
@@ -311,7 +311,7 @@ class ComponentManager
             // Translate human values
             $translate = ['label', 'description', 'options', 'group', 'validationMessage'];
             foreach ($property as $propertyName => $propertyValue) {
-                if (!in_array($propertyName, $translate)) {
+                if (!in_array($propertyName, $translate, true)) {
                     continue;
                 }
 
@@ -364,6 +364,6 @@ class ComponentManager
 
     protected function checkComponentPropertyType(string $type): bool
     {
-        return in_array($type, self::ALLOWED_PROPERTY_TYPES);
+        return in_array($type, self::ALLOWED_PROPERTY_TYPES, true);
     }
 }

--- a/src/System/Classes/Controller.php
+++ b/src/System/Classes/Controller.php
@@ -27,7 +27,7 @@ use Override;
  * /admin/(any)             `admin`, `location` or `system` app directory
  * /admin/acme/cod/(any)    `Acme.Cod` extension
  * /(any)                   `main` app directory
- * @see \Igniter\Admin\Classes\AdminController|\Igniter\Main\Classes\MainController  controller class
+ * @see AdminController|MainController  controller class
  * @deprecated No longer used, will be removed in v5.0.0
  * @codeCoverageIgnore
  */

--- a/src/System/DashboardWidgets/News.php
+++ b/src/System/DashboardWidgets/News.php
@@ -64,7 +64,7 @@ class News extends BaseDashboardWidget
             ];
         }
 
-        $newsCount = $this->property('newsCount');
+        $newsCount = (int)$this->property('newsCount');
         $count = (($count = count($newsFeed)) < $newsCount) ? $count : $newsCount;
 
         return array_slice($newsFeed, 0, $count);

--- a/src/System/Facades/Assets.php
+++ b/src/System/Facades/Assets.php
@@ -6,6 +6,7 @@ namespace Igniter\System\Facades;
 
 use Igniter\Flame\Assetic\Filter\FilterInterface;
 use Igniter\Main\Classes\Theme;
+use Igniter\System\Libraries\Template;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Facade;
 use Override;
@@ -48,7 +49,7 @@ class Assets extends Facade
 {
     /**
      * Get the registered name of the component.
-     * @see \Igniter\System\Libraries\Template
+     * @see Template
      */
     #[Override]
     protected static function getFacadeAccessor(): string

--- a/src/System/Helpers/ValidationHelper.php
+++ b/src/System/Helpers/ValidationHelper.php
@@ -15,7 +15,7 @@ class ValidationHelper
         $result = [];
 
         if (!isset($rules[0])) {
-            return $result;
+            return $rules;
         }
 
         foreach ($rules as $name => $value) {

--- a/src/System/Libraries/Assets.php
+++ b/src/System/Libraries/Assets.php
@@ -382,7 +382,7 @@ class Assets
 
     protected function transformJsObjectVar(mixed $value): false|string
     {
-        if ($value instanceof JsonSerializable || $value instanceof StdClass) {
+        if ($value instanceof JsonSerializable || $value instanceof stdClass) {
             return json_encode($value);
         }
 

--- a/src/System/Libraries/Country.php
+++ b/src/System/Libraries/Country.php
@@ -62,7 +62,7 @@ class Country
     {
         $this->loadCountries();
 
-        /** @var \Igniter\System\Models\Country $countryModel */
+        /** @var CountryModel $countryModel */
         if (!$countryModel = $this->countriesCollection->get($id)) {
             return null;
         }
@@ -74,7 +74,7 @@ class Country
     {
         $this->loadCountries();
 
-        /** @var \Igniter\System\Models\Country $countryModel */
+        /** @var CountryModel $countryModel */
         if (!$countryModel = $this->countriesCollection->get($id)) {
             return null;
         }
@@ -87,7 +87,7 @@ class Country
     {
         $this->loadCountries();
 
-        /** @var \Igniter\System\Models\Country $countryModel */
+        /** @var CountryModel $countryModel */
         if (!$countryModel = $this->countriesCollection->firstWhere('iso_code_2', $isoCodeTwo)) {
             return null;
         }
@@ -137,7 +137,7 @@ class Country
         } elseif (is_numeric($country)) {
             $this->loadCountries();
 
-            /** @var \Igniter\System\Models\Country $countryModel */
+            /** @var CountryModel $countryModel */
             if ($countryModel = $this->countriesCollection->get($country)) {
                 $result['country'] = $countryModel->country_name;
                 $result['format'] = $countryModel->format;

--- a/src/System/Models/Currency.php
+++ b/src/System/Models/Currency.php
@@ -166,8 +166,11 @@ class Currency extends Model implements CurrencyInterface
     #[Override]
     public function getFormat(): string
     {
-        $format = ($this->thousand_sign ?: '!').'0'.$this->decimal_sign;
-        $format .= str_repeat('0', (int)$this->decimal_position);
+        $format = ($this->thousand_sign ?: '!').'0';
+
+        if ((int)$this->decimal_position > 0) {
+            $format .= $this->decimal_sign.str_repeat('0', (int)$this->decimal_position);
+        }
 
         return $this->getSymbolPosition() ? '1'.$format.$this->getSymbol() : $this->getSymbol().'1'.$format;
     }

--- a/src/System/Models/RequestLog.php
+++ b/src/System/Models/RequestLog.php
@@ -66,7 +66,7 @@ class RequestLog extends Model
         ]);
 
         if ($referrer) {
-            $referrers = (array)$record->referrer ?: [];
+            $referrers = (array)$record->referrer;
             $referrers[] = $referrer;
             $record->referrer = $referrers;
         }

--- a/src/System/ServiceProvider.php
+++ b/src/System/ServiceProvider.php
@@ -145,7 +145,7 @@ class ServiceProvider extends AppServiceProvider
 
         foreach ([
             'Assets' => Assets::class,
-            'Country' => \Igniter\System\Facades\Country::class,
+            'Country' => Facades\Country::class,
         ] as $alias => $class) {
             $loader->alias($alias, $class);
         }

--- a/src/System/Traits/ManagesUpdates.php
+++ b/src/System/Traits/ManagesUpdates.php
@@ -51,7 +51,9 @@ trait ManagesUpdates
             'item.type' => ['required', 'in:core,extension,theme'],
             'item.version' => ['required'],
             'item.action' => ['required', 'in:install'],
-        ], [], [
+        ], [
+            'item.package.required' => lang('igniter::system.updates.error_meta_package'),
+        ], [
             'item.code' => lang('igniter::system.updates.label_meta_code'),
             'item.name' => lang('igniter::system.updates.label_meta_name'),
             'item.package' => lang('igniter::system.updates.label_meta_package'),

--- a/tests/src/Flame/Composer/ManagerTest.php
+++ b/tests/src/Flame/Composer/ManagerTest.php
@@ -8,8 +8,10 @@ use Composer\Autoload\ClassLoader;
 use Exception;
 use Igniter\Flame\Composer\Manager;
 use Igniter\Flame\Support\Facades\File;
+use ReflectionMethod;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
 
 it('loads package version correctly', function() {
     $version = resolve(Manager::class)->getPackageVersion('some-package');
@@ -266,4 +268,57 @@ it('does not modify composer config if repository exists', function() {
 it('throws exception when composer file does not exists when modifying composer config', function() {
     $manager = new Manager(__DIR__, '/storage');
     expect(fn() => $manager->assertSchema())->toThrow(RuntimeException::class);
+});
+
+it('injects COMPOSER_HOME when the parent process has neither set', function() {
+    $originalComposerHome = getenv('COMPOSER_HOME');
+    putenv('COMPOSER_HOME');
+
+    try {
+        $manager = new Manager('/root', '/storage');
+        $method = new ReflectionMethod(Manager::class, 'getProcess');
+
+        /** @var Process $process */
+        $process = $method->invoke($manager, ['composer', 'install'], ['COMPOSER_MEMORY_LIMIT' => '-1']);
+
+        expect($process)->toBeInstanceOf(Process::class)
+            ->and($process->getEnv())->toMatchArray([
+                'COMPOSER_HOME' => '/storage',
+                'COMPOSER_MEMORY_LIMIT' => '-1',
+            ]);
+    } finally {
+        $originalComposerHome === false ? putenv('COMPOSER_HOME') : putenv('COMPOSER_HOME='.$originalComposerHome);
+    }
+});
+
+it('does not override COMPOSER_HOME inherited from the parent process', function() {
+    $originalComposerHome = getenv('COMPOSER_HOME');
+    putenv('COMPOSER_HOME=/parent/composer');
+
+    try {
+        $manager = new Manager('/root', '/storage');
+        $method = new ReflectionMethod(Manager::class, 'getProcess');
+
+        /** @var Process $process */
+        $process = $method->invoke($manager, ['composer', 'install']);
+
+        expect($process->getEnv())
+            ->and($process->getEnv())->not->toHaveKey('COMPOSER_HOME');
+    } finally {
+        $originalComposerHome === false ? putenv('COMPOSER_HOME') : putenv('COMPOSER_HOME='.$originalComposerHome);
+    }
+});
+
+it('allows callers to override COMPOSER_HOME on the spawned composer process', function() {
+    $manager = new Manager('/root', '/storage');
+    $method = new ReflectionMethod(Manager::class, 'getProcess');
+
+    /** @var Process $process */
+    $process = $method->invoke($manager, ['composer', 'install'], [
+        'COMPOSER_HOME' => '/custom/composer',
+    ]);
+
+    expect($process->getEnv())->toMatchArray([
+        'COMPOSER_HOME' => '/custom/composer',
+    ]);
 });

--- a/tests/src/Flame/Currency/CurrencyTest.php
+++ b/tests/src/Flame/Currency/CurrencyTest.php
@@ -59,6 +59,22 @@ it('formats value to currency string when thousand sign is missing', function() 
     expect(resolve(Currency::class)->format(1234.56, 'ABC'))->toBe('£1234.56');
 });
 
+it('formats value to currency string for zero-decimal currencies', function() {
+    CurrencyModel::factory()->create([
+        'currency_code' => 'VND',
+        'currency_symbol' => 'd',
+        'currency_rate' => 1.0,
+        'currency_status' => 1,
+        'symbol_position' => false,
+        'thousand_sign' => ',',
+        'decimal_sign' => '.',
+        'decimal_position' => 0,
+    ]);
+
+    expect(resolve(Currency::class)->format(1234.56, 'VND'))->toBe('d1,235')
+        ->and(resolve(Currency::class)->format(-1234.56, 'VND'))->toBe('-d1,235');
+});
+
 it('returns null for invalid to currency rate', function() {
     CurrencyModel::factory()->create([
         'currency_code' => 'ABC',

--- a/tests/src/System/Models/CurrencyTest.php
+++ b/tests/src/System/Models/CurrencyTest.php
@@ -81,6 +81,18 @@ it('returns correct currency format with symbol at the beginning', function() {
     expect($currency->getFormat())->toBe('$1,0.00');
 });
 
+it('returns correct currency format for zero-decimal currencies', function() {
+    $currency = new Currency([
+        'currency_symbol' => 'd',
+        'symbol_position' => false,
+        'thousand_sign' => ',',
+        'decimal_sign' => '.',
+        'decimal_position' => 0,
+    ]);
+
+    expect($currency->getFormat())->toBe('d1,0');
+});
+
 it('configures model correctly', function() {
     $currency = new Currency;
 


### PR DESCRIPTION
'## ✨ New Features

### Zero-decimal currency support
Currencies that do not use decimal places (e.g. JPY, KRW) are now formatted correctly without trailing zeros or decimal separators. Includes dedicated handling to normalize zero-decimal values at the formatting layer.

- #46 — Fix zero-decimal currency formatting
- #47 — Support no-decimals currency

---

## 🐛 Bug Fixes

### News widget array slice error on dashboard
Fixed an array slicing bug in the dashboard news widget that caused incorrect data rendering or crashes when the data array had unexpected bounds.

- #48 — Bug: array slice issue fixed for news widget on dashboard

### 
Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in phar:///usr/local/bin/composer/vendor/react/promise/src/functions.php on line 300
   ______
  / ____/___  ____ ___  ____  ____  ________  _____
 / /   / __ \/ __ `__ \/ __ \/ __ \/ ___/ _ \/ ___/
/ /___/ /_/ / / / / / / /_/ / /_/ (__  )  __/ /
\____/\____/_/ /_/ /_/ .___/\____/____/\___/_/
                    /_/
Composer version 2.7.7 2024-06-10 22:11:12

Usage:
  command [options] [arguments]

Options:
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
  -n, --no-interaction           Do not ask any interactive question
      --profile                  Display timing and memory usage information
      --no-plugins               Whether to disable plugins.
      --no-scripts               Skips the execution of all scripts defined in composer.json file.
  -d, --working-dir=WORKING-DIR  If specified, use the given directory as working directory.
      --no-cache                 Prevent use of the cache
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  about                Shows a short information about Composer
  archive              Creates an archive of this composer package
  audit                Checks for security vulnerability advisories for installed packages
  browse               [home] Opens the package's repository URL or homepage in your browser
  bump                 Increases the lower limit of your composer.json requirements to the currently installed versions
  check-platform-reqs  Check that platform requirements are satisfied
  clear-cache          [clearcache|cc] Clears composer's internal package cache
  completion           Dump the shell completion script
  config               Sets config options
  create-project       Creates new project from a package into given directory
  depends              [why] Shows which packages cause the given package to be installed
  diagnose             Diagnoses the system to identify common errors
  dump-autoload        [dumpautoload] Dumps the autoloader
  exec                 Executes a vendored binary/script
  fund                 Discover how to help fund the maintenance of your dependencies
  global               Allows running commands in the global composer dir ($COMPOSER_HOME)
  help                 Display help for a command
  init                 Creates a basic composer.json file in current directory
  install              [i] Installs the project dependencies from the composer.lock file if present, or falls back on the composer.json
  licenses             Shows information about licenses of dependencies
  list                 List commands
  outdated             Shows a list of installed packages that have updates available, including their latest version
  prohibits            [why-not] Shows which packages prevent the given package from being installed
  reinstall            Uninstalls and reinstalls the given package names
  remove               [rm|uninstall] Removes a package from the require or require-dev
  require              [r] Adds required packages to your composer.json and installs them
  run-script           [run] Runs the scripts defined in composer.json
  search               Searches for packages
  self-update          [selfupdate] Updates composer.phar to the latest version
  show                 [info] Shows information about packages
  status               Shows a list of locally modified packages
  suggests             Shows package suggestions
  test                 Runs the test script as defined in composer.json
  update               [u|upgrade] Updates your dependencies to the latest version according to composer.json, and updates the composer.lock file
  validate             Validates a composer.json and composer.lock
 test
  test:coverage        Runs the test:coverage script as defined in composer.json
  test:lint            Runs the test:lint script as defined in composer.json
  test:lint-fix        Runs the test:lint-fix script as defined in composer.json
  test:pest            Runs the test:pest script as defined in composer.json
  test:pest-ci         Runs the test:pest-ci script as defined in composer.json
  test:refactor        Runs the test:refactor script as defined in composer.json
  test:refactor-fix    Runs the test:refactor-fix script as defined in composer.json
  test:static          Runs the test:static script as defined in composer.json
  test:static-fix      Runs the test:static-fix script as defined in composer.json
  test:type-coverage   Runs the test:type-coverage script as defined in composer.json — Environment variables when spawning composer process
 and  are now explicitly set when spawning the composer process, preventing failures in environments where these variables are absent or misconfigured.

- #49 — fix(composer): set HOME and COMPOSER_HOME when spawning composer process

###  — Checkbox list submits empty value correctly
The checkbox list component in admin forms now correctly submits an empty value when no options are selected, rather than omitting the field entirely.

- 53947e91 — fix(admin-form): ensure checkboxlist submits empty value

###  — Custom error message for missing 
Added a descriptive error message when  is missing, replacing a generic or silent failure with a clear, actionable system message.

- a8432a1c — fix(system): add custom error message for missing '