### PR TITLE
Release v4.2.5

### DIFF
--- a/src/Flame/Support/Igniter.php
+++ b/src/Flame/Support/Igniter.php
@@ -13,7 +13,7 @@ use Illuminate\View\Factory;
 
 class Igniter
 {
-    protected const string VERSION = 'v4.2.4';
+    protected const string VERSION = 'v4.2.5';
 
     /**
      * The base path for extensions.

--- a/src/Main/Http/Middleware/CheckInitialSetup.php
+++ b/src/Main/Http/Middleware/CheckInitialSetup.php
@@ -14,7 +14,7 @@ class CheckInitialSetup
 {
     public function handle(Request $request, Closure $next): mixed
     {
-        if (!Igniter::runningInAdmin() && Igniter::hasDatabase() && $this->needsInitialSetup()) {
+        if (Igniter::hasDatabase() && $request->routeIs('igniter.theme.*') && $this->needsInitialSetup()) {
             return redirect(admin_url());
         }
 

--- a/src/Main/Http/Middleware/CheckInitialSetup.php
+++ b/src/Main/Http/Middleware/CheckInitialSetup.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Igniter\Main\Http\Middleware;
+
+use Closure;
+use Igniter\Flame\Support\Facades\Igniter;
+use Igniter\Local\Models\Location;
+use Igniter\User\Models\User;
+use Illuminate\Http\Request;
+
+class CheckInitialSetup
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        if (!Igniter::runningInAdmin() && Igniter::hasDatabase() && $this->needsInitialSetup()) {
+            return redirect(admin_url());
+        }
+
+        return $next($request);
+    }
+
+    protected function needsInitialSetup(): bool
+    {
+        return User::query()->doesntExist() || Location::query()->doesntExist();
+    }
+}

--- a/src/Main/ServiceProvider.php
+++ b/src/Main/ServiceProvider.php
@@ -11,6 +11,7 @@ use Igniter\Main\Classes\RouteRegistrar;
 use Igniter\Main\Classes\ThemeManager;
 use Igniter\Main\Components\BlankComponent;
 use Igniter\Main\Components\ViewBag;
+use Igniter\Main\Http\Middleware\CheckInitialSetup;
 use Igniter\Main\Http\Middleware\CheckMaintenance;
 use Igniter\Main\Providers\AssetsServiceProvider;
 use Igniter\Main\Providers\FormServiceProvider;
@@ -55,6 +56,7 @@ class ServiceProvider extends AppServiceProvider
         Igniter::loadControllersFrom(igniter_path('src/Main/Http/Controllers'), 'Igniter\\Main\\Http\\Controllers');
 
         Route::pushMiddlewareToGroup('igniter', CheckMaintenance::class);
+        Route::pushMiddlewareToGroup('igniter', CheckInitialSetup::class);
 
         $this->app->register(AssetsServiceProvider::class);
         $this->app->register(FormServiceProvider::class);

--- a/src/Main/Widgets/MediaManager.php
+++ b/src/Main/Widgets/MediaManager.php
@@ -12,6 +12,8 @@ use Igniter\Admin\Traits\ValidatesForm;
 use Igniter\Flame\Exception\FlashException;
 use Igniter\Flame\Support\Facades\File;
 use Igniter\Main\Classes\MediaLibrary;
+use Igniter\System\Models\Settings;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Str;
@@ -625,10 +627,16 @@ class MediaManager extends BaseWidget
 
             $data = $this->validate(request()->all(), [
                 'path' => ['required', 'string', 'starts_with:/', $this->validateFileExists()],
-                'file_data' => ['required', 'file', 'mimes:'.implode(',', $mediaLibrary->getAllowedExtensions())],
+                'file_data' => [
+                    'required',
+                    'file',
+                    'mimes:'.implode(',', $mediaLibrary->getAllowedExtensions()),
+                    'mimetypes:'.implode(',', Settings::getAllowedMimeTypes()),
+                ],
             ], [
                 'starts_with' => lang('igniter::main.media_manager.alert_invalid_path'),
                 'mimes' => lang('igniter::main.media_manager.alert_extension_not_allowed'),
+                'mimetypes' => lang('igniter::main.media_manager.alert_extension_not_allowed'),
                 'file' => lang('igniter::main.media_manager.alert_file_not_found'),
             ]);
 

--- a/src/Main/Widgets/MediaManager.php
+++ b/src/Main/Widgets/MediaManager.php
@@ -12,8 +12,6 @@ use Igniter\Admin\Traits\ValidatesForm;
 use Igniter\Flame\Exception\FlashException;
 use Igniter\Flame\Support\Facades\File;
 use Igniter\Main\Classes\MediaLibrary;
-use Igniter\System\Models\Settings;
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Str;

--- a/src/Main/Widgets/MediaManager.php
+++ b/src/Main/Widgets/MediaManager.php
@@ -631,7 +631,7 @@ class MediaManager extends BaseWidget
                     'required',
                     'file',
                     'mimes:'.implode(',', $mediaLibrary->getAllowedExtensions()),
-                    'mimetypes:'.implode(',', Settings::getAllowedMimeTypes()),
+                    'extensions:'.implode(',', $mediaLibrary->getAllowedExtensions()),
                 ],
             ], [
                 'starts_with' => lang('igniter::main.media_manager.alert_invalid_path'),

--- a/src/System/Console/Commands/IgniterInstall.php
+++ b/src/System/Console/Commands/IgniterInstall.php
@@ -98,7 +98,7 @@ class IgniterInstall extends Command
             $this->openBrowser('https://github.com/tastyigniter/TastyIgniter');
         }
 
-        $this->alert(sprintf(self::LOGIN_TO_ADMIN_DASHBOARD, admin_url('login')));
+        $this->alert(sprintf(self::LOGIN_TO_ADMIN_DASHBOARD, config('app.url').'/admin'));
 
         return null;
     }

--- a/src/System/Models/Settings.php
+++ b/src/System/Models/Settings.php
@@ -415,4 +415,18 @@ class Settings extends Model
             'mp3', 'wav', 'wma', 'm4a', 'ogg', 'oga',
         ]);
     }
+
+    public static function getAllowedMimeTypes(): array
+    {
+        return [
+            'image/jpeg', 'image/jpeg', 'image/png', 'image/gif', 'image/bmp', 'image/x-ms-bmp', 'image/tiff',
+            'image/svg+xml', 'image/x-icon', 'image/vnd.microsoft.icon', 'image/webp',
+            'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/vnd.ms-powerpoint', 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            'application/pdf', 'text/plain', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'video/mp4', 'video/x-msvideo', 'video/avi', 'video/quicktime', 'video/mpeg', 'video/mpeg', 'video/x-matroska', 'video/webm',
+            'audio/ogg', 'video/ogg', 'application/ogg', 'audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav', 'audio/vnd.wave',
+            'audio/x-ms-wma', 'audio/mp4', 'audio/x-m4a', 'audio/m4a',
+        ];
+    }
 }

--- a/src/System/Models/Settings.php
+++ b/src/System/Models/Settings.php
@@ -415,18 +415,4 @@ class Settings extends Model
             'mp3', 'wav', 'wma', 'm4a', 'ogg', 'oga',
         ]);
     }
-
-    public static function getAllowedMimeTypes(): array
-    {
-        return [
-            'image/jpeg', 'image/jpeg', 'image/png', 'image/gif', 'image/bmp', 'image/x-ms-bmp', 'image/tiff',
-            'image/svg+xml', 'image/x-icon', 'image/vnd.microsoft.icon', 'image/webp',
-            'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            'application/vnd.ms-powerpoint', 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-            'application/pdf', 'text/plain', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            'video/mp4', 'video/x-msvideo', 'video/avi', 'video/quicktime', 'video/mpeg', 'video/mpeg', 'video/x-matroska', 'video/webm',
-            'audio/ogg', 'video/ogg', 'application/ogg', 'audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-wav', 'audio/vnd.wave',
-            'audio/x-ms-wma', 'audio/mp4', 'audio/x-m4a', 'audio/m4a',
-        ];
-    }
 }

--- a/src/System/Traits/ViewMaker.php
+++ b/src/System/Traits/ViewMaker.php
@@ -40,7 +40,7 @@ trait ViewMaker
 
         $guess = collect($paths)
             ->prepend($prefix, $view)
-            ->reduce(function($carry, $directory, $prefix) use ($view) {
+            ->reduce(function($carry, $directory, string $prefix) use ($view) {
                 if (!is_null($carry)) {
                     return $carry;
                 }
@@ -72,7 +72,7 @@ trait ViewMaker
 
         $guess = collect($paths)
             ->prepend($prefix, $view)
-            ->reduce(function($carry, $directory, $prefix) use ($view) {
+            ->reduce(function($carry, $directory, string $prefix) use ($view) {
                 if (!is_null($carry)) {
                     return $carry;
                 }

--- a/tests/src/Main/Http/Middleware/CheckInitialSetupTest.php
+++ b/tests/src/Main/Http/Middleware/CheckInitialSetupTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Igniter\Tests\Main\Http\Middleware;
+
+use Igniter\Flame\Support\Facades\Igniter;
+use Igniter\Main\Http\Middleware\CheckInitialSetup;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Mockery;
+
+it('allows request to proceed when initial setup is complete', function() {
+    $request = Request::create('/some-url', 'GET');
+    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(false);
+    Igniter::partialMock()->shouldReceive('hasDatabase')->andReturn(true);
+
+    $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();
+    $middleware->shouldAllowMockingProtectedMethods();
+    $middleware->shouldReceive('needsInitialSetup')->andReturn(false);
+
+    expect($middleware->handle($request, fn($req) => 'next'))->toBe('next');
+});
+
+it('allows request to proceed when in admin area', function() {
+    $request = Request::create('/admin/some-url', 'GET');
+    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(true);
+
+    $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();
+    $middleware->shouldAllowMockingProtectedMethods();
+    $middleware->shouldReceive('needsInitialSetup')->never();
+
+    expect($middleware->handle($request, fn($req) => 'next'))->toBe('next');
+});
+
+it('allows request to proceed when database is missing', function() {
+    $request = Request::create('/some-url', 'GET');
+    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(false);
+    Igniter::partialMock()->shouldReceive('hasDatabase')->andReturn(false);
+
+    $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();
+    $middleware->shouldAllowMockingProtectedMethods();
+    $middleware->shouldReceive('needsInitialSetup')->never();
+
+    expect($middleware->handle($request, fn($req) => 'next'))->toBe('next');
+});
+
+it('redirects to admin when initial setup is required', function() {
+    $request = Request::create('/some-url', 'GET');
+    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(false);
+    Igniter::partialMock()->shouldReceive('hasDatabase')->andReturn(true);
+
+    $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();
+    $middleware->shouldAllowMockingProtectedMethods();
+    $middleware->shouldReceive('needsInitialSetup')->andReturn(true);
+
+    $response = $middleware->handle($request, fn($req) => 'next');
+
+    expect($response)->toBeInstanceOf(RedirectResponse::class)
+        ->and($response->getTargetUrl())->toBe(admin_url());
+});

--- a/tests/src/Main/Http/Middleware/CheckInitialSetupTest.php
+++ b/tests/src/Main/Http/Middleware/CheckInitialSetupTest.php
@@ -8,11 +8,21 @@ use Igniter\Flame\Support\Facades\Igniter;
 use Igniter\Main\Http\Middleware\CheckInitialSetup;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
 use Mockery;
 
-it('allows request to proceed when initial setup is complete', function() {
-    $request = Request::create('/some-url', 'GET');
-    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(false);
+function createRequestWithRoute(string $uri, string $routeName): Request
+{
+    $request = Request::create($uri, 'GET');
+    $route = new Route('GET', $uri, []);
+    $route->name($routeName);
+    $request->setRouteResolver(fn() => $route);
+
+    return $request;
+}
+
+it('allows request to proceed when initial setup is complete on a theme route', function() {
+    $request = createRequestWithRoute('/', 'igniter.theme.home');
     Igniter::partialMock()->shouldReceive('hasDatabase')->andReturn(true);
 
     $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();
@@ -22,9 +32,9 @@ it('allows request to proceed when initial setup is complete', function() {
     expect($middleware->handle($request, fn($req) => 'next'))->toBe('next');
 });
 
-it('allows request to proceed when in admin area', function() {
-    $request = Request::create('/admin/some-url', 'GET');
-    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(true);
+it('allows request to proceed when not on a theme route', function() {
+    $request = createRequestWithRoute('/admin/some-url', 'igniter.admin.dashboard');
+    Igniter::partialMock()->shouldReceive('hasDatabase')->andReturn(true);
 
     $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();
     $middleware->shouldAllowMockingProtectedMethods();
@@ -34,8 +44,7 @@ it('allows request to proceed when in admin area', function() {
 });
 
 it('allows request to proceed when database is missing', function() {
-    $request = Request::create('/some-url', 'GET');
-    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(false);
+    $request = createRequestWithRoute('/', 'igniter.theme.home');
     Igniter::partialMock()->shouldReceive('hasDatabase')->andReturn(false);
 
     $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();
@@ -45,9 +54,8 @@ it('allows request to proceed when database is missing', function() {
     expect($middleware->handle($request, fn($req) => 'next'))->toBe('next');
 });
 
-it('redirects to admin when initial setup is required', function() {
-    $request = Request::create('/some-url', 'GET');
-    Igniter::partialMock()->shouldReceive('runningInAdmin')->andReturn(false);
+it('redirects to admin when initial setup is required on a theme route', function() {
+    $request = createRequestWithRoute('/', 'igniter.theme.home');
     Igniter::partialMock()->shouldReceive('hasDatabase')->andReturn(true);
 
     $middleware = Mockery::mock(CheckInitialSetup::class)->makePartial();

--- a/tests/src/Main/Providers/PagicServiceProviderTest.php
+++ b/tests/src/Main/Providers/PagicServiceProviderTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Igniter\Tests\Main\Providers;
 
+use Igniter\Main\Http\Middleware\CheckInitialSetup;
+
 it('resolves page route binding', function() {
-    $result = $this->get('/components');
+    $result = $this->withoutMiddleware(CheckInitialSetup::class)->get('/components');
     $result->assertStatus(200);
     $result->assertSee('This is a test component partial content');
 });


### PR DESCRIPTION
This release introduces new middleware for guiding incomplete setups and improves file upload validation in the media manager.

## Added

- Added a `CheckInitialSetup` middleware that redirects users to the setup flow when initial configuration is incomplete
- Added MIME type and extension-based validation for file uploads in the media manager

## Fixed

- Restricted the `CheckInitialSetup` redirect logic to apply only to theme routes, preventing unintended redirects elsewhere

## Changed

- Replaced `getAllowedMimeTypes` with extension-based validation for media file handling
- Added type hints and removed unused imports in the media manager for improved code clarity