### PR TITLE
fix: prevent Sortable trait from overwriting explicitly set priority of 0

### DIFF
--- a/src/Flame/Database/Traits/Sortable.php
+++ b/src/Flame/Database/Traits/Sortable.php
@@ -40,7 +40,8 @@ trait Sortable
             $sortOrderColumn = $model->getSortOrderColumn();
 
             // only automatically calculate next position with max+1 when a position has not been set already
-            if ($model->sortWhenCreating() && $sortOrderColumn && empty($model->getAttributeValue($sortOrderColumn))) {
+            $currentOrder = $model->getAttributeValue($sortOrderColumn);
+            if ($model->sortWhenCreating() && $sortOrderColumn && ($currentOrder === null || $currentOrder === '')) {
                 $model->setAttribute($sortOrderColumn, static::on()->max($sortOrderColumn) + 1);
             }
         });

--- a/src/Flame/Database/Traits/Sortable.php
+++ b/src/Flame/Database/Traits/Sortable.php
@@ -40,9 +40,11 @@ trait Sortable
             $sortOrderColumn = $model->getSortOrderColumn();
 
             // only automatically calculate next position with max+1 when a position has not been set already
-            $currentOrder = $model->getAttributeValue($sortOrderColumn);
-            if ($model->sortWhenCreating() && $sortOrderColumn && ($currentOrder === null || $currentOrder === '')) {
-                $model->setAttribute($sortOrderColumn, static::on()->max($sortOrderColumn) + 1);
+            if ($model->sortWhenCreating() && $sortOrderColumn) {
+                $currentOrder = $model->getAttributeValue($sortOrderColumn);
+                if ($currentOrder === null || $currentOrder === '') {
+                    $model->setAttribute($sortOrderColumn, static::on()->max($sortOrderColumn) + 1);
+                }
             }
         });
     }


### PR DESCRIPTION
## Problem

When creating records with an explicitly set `priority` of `0`, the `Sortable` trait's `creating` hook overwrites it with `max(priority) + 1`, pushing the record to the end of the sorted list.

This is caused by using PHP's `empty()` to check whether a sort position has been set:

```php
if ($model->sortWhenCreating() && $sortOrderColumn && empty($model->getAttributeValue($sortOrderColumn))) {
```

`empty(0) === true` in PHP, so a legitimate `priority = 0` is mistaken for "no priority set".

**Observed symptom:** The `Repeater` widget assigns 0-based priorities to form values. The first item always receives `priority = 0`, which the `Sortable` hook then overwrites — causing the first item to appear last after saving.

## Fix

Replace `empty()` with a strict `null`/empty-string check so that an explicitly set `priority = 0` is preserved:

```php
$currentOrder = $model->getAttributeValue($sortOrderColumn);
if ($model->sortWhenCreating() && $sortOrderColumn && ($currentOrder === null || $currentOrder === '')) {
```

## Impact

- Only affects models using the `Sortable` trait with `sortWhenCreating = true`
- No behaviour change when priority is genuinely unset (`null` or `''`)
- Preserves `0` as a valid, explicit sort position

Fixes: https://github.com/tastyigniter/TastyIgniter/issues/1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)