### PR TITLE
fix: reset active tab to default when opening a new or different record

### DIFF
--- a/src/Admin/Widgets/Form.php
+++ b/src/Admin/Widgets/Form.php
@@ -310,7 +310,9 @@ class Form extends BaseWidget
             'tab' => ['required', 'string'],
         ])->validate();
 
-        $this->putSession('activeTab', $data['tab']);
+        if ($this->context !== 'create') {
+            $this->putSession($this->activeTabSessionKey(), $data['tab']);
+        }
     }
 
     /**
@@ -658,13 +660,20 @@ class Form extends BaseWidget
         $this->activeTab = $tab;
     }
 
+    protected function activeTabSessionKey(): string
+    {
+        $recordId = $this->model?->getKey() ?? 'new';
+
+        return 'activeTab.'.$this->context.'.'.$recordId;
+    }
+
     public function getActiveTab(): ?string
     {
         $tabs = $this->allTabs['primary'];
         $type = $tabs->section;
 
         $defaultTab = '#'.$type.'tab-1';
-        $activeTab = $this->getSession('activeTab') ?? $defaultTab;
+        $activeTab = ($this->context !== 'create' ? $this->getSession($this->activeTabSessionKey()) : null) ?? $defaultTab;
         $activeTabIndex = (int)str_after($activeTab, $defaultTab);
 
         // In cases where a tab has been removed, the first tab becomes the active tab

--- a/src/Admin/Widgets/Form.php
+++ b/src/Admin/Widgets/Form.php
@@ -661,11 +661,11 @@ class Form extends BaseWidget
     }
 
     protected function activeTabSessionKey(): string
-    {
-        $recordId = $this->model?->getKey() ?? 'new';
+{
+            $recordId = $this->model?->getKey() ?? md5((string)request()->url());
 
-        return 'activeTab.'.$this->context.'.'.$recordId;
-    }
+            return 'activeTab.'.$this->context.'.'.$recordId;
+        }
 
     public function getActiveTab(): ?string
     {


### PR DESCRIPTION
## Problem

The active tab was stored in the session under a key derived solely from the form widget's class name — making it global across all records. Navigating to a non-default tab on any record would cause that same tab to be active when opening a new record or a different record.

Fixes tastyigniter/TastyIgniter#1177

## Root cause

`SessionMaker::makeSessionKey()` returns a constant string (the widget class name). All `putSession('activeTab', ...)` / `getSession('activeTab')` calls shared a single session slot regardless of which record was open or whether the form was in create/edit context.

## Fix

- Introduced `activeTabSessionKey()` which namespaces the key per context and record ID (`activeTab.edit.{id}`)
- For the `create` context: never read or write the active tab to session — create forms always start on tab 1
- For the `edit` context: tab is remembered per individual record

## Behaviour after fix
- Opening a new create form → always lands on tab 1 ✓
- Opening a different edit record → always lands on tab 1 ✓
- Returning to the same edit record → restores the last tab viewed on that record ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)