### PR TITLE
fix: PostgreSQL compatibility in dashboard charts, mail template sync, and form validation

### DIFF
--- a/src/Admin/Traits/HasChartDatasets.php
+++ b/src/Admin/Traits/HasChartDatasets.php
@@ -29,8 +29,11 @@ trait HasChartDatasets
     {
         $dateColumnName = $config['column'];
 
+        $dateFmt = DB::getDriverName() === 'pgsql'
+            ? DB::raw("to_char({$dateColumnName}, 'YYYY-MM-DD') as x")
+            : DB::raw('DATE_FORMAT('.$dateColumnName.', "%Y-%m-%d") as x');
         $query = $config['model']::query()->select(
-            DB::raw('DATE_FORMAT('.$dateColumnName.', "%Y-%m-%d") as x'),
+            $dateFmt,
             DB::raw('count(*) as y'),
         )->whereBetween($dateColumnName, [$start, $end])->groupBy('x');
 

--- a/src/System/Classes/FormRequest.php
+++ b/src/System/Classes/FormRequest.php
@@ -54,7 +54,9 @@ class FormRequest extends BaseFormRequest
 
     protected function getRecordId(): int|string|null
     {
-        return ($slug = $this->route('slug'))
+        $id = ($slug = $this->route('slug'))
             ? str_after($slug, '/') : null;
+
+        return is_numeric($id) ? $id : null;
     }
 }

--- a/src/System/Models/MailTemplate.php
+++ b/src/System/Models/MailTemplate.php
@@ -142,14 +142,11 @@ class MailTemplate extends Model
 
         // Create new templates
         foreach ($newTemplates as $name => $label) {
-            $sections = self::getTemplateSections($name);
-            $layoutCode = array_get($sections, 'settings.layout', 'default');
-
             $templateModel = new MailTemplate;
             $templateModel->code = $name;
+            $templateModel->fillFromView();
             $templateModel->label = $label;
             $templateModel->is_custom = false;
-            $templateModel->layout_id = MailLayout::getIdFromCode($layoutCode);
             $templateModel->save();
         }
     }


### PR DESCRIPTION
## Problem

Three bugs discovered when running TastyIgniter on **PostgreSQL** (tested with PostgreSQL 18):

---

### 1. Dashboard 500 — `column "%Y-%m-%d" does not exist`

**File:** `src/Admin/Traits/HasChartDatasets.php`

`queryDatasets()` uses `DATE_FORMAT()` which is MySQL-only. PostgreSQL has no such function — it uses `to_char()` instead.

**Fix:** Detect the driver and use the appropriate date formatting function.

```php
// Before
DB::raw('DATE_FORMAT('.$dateColumnName.', "%Y-%m-%d") as x'),

// After
$dateFmt = DB::getDriverName() === 'pgsql'
    ? DB::raw("to_char({$dateColumnName}, 'YYYY-MM-DD') as x")
    : DB::raw('DATE_FORMAT('.$dateColumnName.', "%Y-%m-%d") as x');
```

---

### 2. Settings/Dashboard 500 — `null value in column "subject" violates not-null constraint`

**File:** `src/System/Models/MailTemplate.php`

`syncAll()` creates new mail template records without calling `fillFromView()`, leaving `subject` as NULL. PostgreSQL enforces the NOT NULL constraint strictly (MySQL silently allows it in some modes).

`findOrMakeTemplate()` correctly calls `fillFromView()` — `syncAll()` should do the same.

**Fix:** Call `fillFromView()` in the `syncAll()` create loop, which internally sets `subject`, `body`, `plain_body`, and `layout_id` from the view template.

```php
// Before — subject never set, layout_id set manually
foreach ($newTemplates as $name => $label) {
    $sections = self::getTemplateSections($name);
    $layoutCode = array_get($sections, 'settings.layout', 'default');
    $templateModel = new MailTemplate;
    $templateModel->code = $name;
    $templateModel->label = $label;
    $templateModel->is_custom = false;
    $templateModel->layout_id = MailLayout::getIdFromCode($layoutCode);
    $templateModel->save();
}

// After — fillFromView() populates subject, body, plain_body, layout_id
foreach ($newTemplates as $name => $label) {
    $templateModel = new MailTemplate;
    $templateModel->code = $name;
    $templateModel->fillFromView();
    $templateModel->label = $label;
    $templateModel->is_custom = false;
    $templateModel->save();
}
```

---

### 3. Customer create 500 — `invalid input syntax for type bigint: "create"`

**File:** `src/System/Classes/FormRequest.php`

`getRecordId()` returns `str_after($slug, '/')` where `$slug` is the route parameter. On create routes the slug is literally `"create"`, which gets passed to `Rule::unique()->ignore("create", "customer_id")`. PostgreSQL cannot cast the string `"create"` to `bigint` and throws an error.

**Fix:** Guard the return value — only return numeric IDs; return `null` otherwise (which disables the `ignore()` clause, correctly enforcing uniqueness on create).

```php
// Before
protected function getRecordId(): int|string|null
{
    return ($slug = $this->route('slug'))
        ? str_after($slug, '/') : null;
}

// After
protected function getRecordId(): int|string|null
{
    $id = ($slug = $this->route('slug'))
        ? str_after($slug, '/') : null;

    return is_numeric($id) ? $id : null;
}
```

---

## Notes

- All three issues are MySQL-specific assumptions that fail silently on MySQL but raise hard errors on PostgreSQL.
- Fix 2 also makes `syncAll()` consistent with `findOrMakeTemplate()` which already calls `fillFromView()`.
- Fix 3 is semantically correct regardless of database: the `ignore()` clause should never receive a non-numeric string.