### PR TITLE
Add Psalm security (taint) analysis — complementary to Larastan

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -63,7 +63,7 @@ jobs:
       # Taint-only baseline suppresses today's findings; new ones surface. A taint-only baseline (no
       # type entries) does not trip UnusedBaselineEntry in taint mode, so --use-baseline is safe here.
       - name: Run Psalm (taint analysis)
-        run: ./vendor/bin/psalm --taint-analysis --use-baseline=psalm-baseline.xml --report=psalm.sarif --report-show-info=false
+        run: ./vendor/bin/psalm --taint-analysis --use-baseline=psalm-baseline.xml --no-progress --report=psalm.sarif --report-show-info=false
 
       - name: Upload SARIF to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -28,6 +28,11 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    env:
+      # This package's require-dev pulls its own ti-ext-* extensions, which require
+      # tastyigniter/core ^4.0. On a PR the root package resolves as dev-<sha> (no version),
+      # so tell Composer the root version — mirrors `composer config version 4.0.x-dev` in pipeline.yml.
+      COMPOSER_ROOT_VERSION: 4.0.x-dev
     steps:
       - name: Block unexpected egress
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,77 @@
+# Psalm security (taint) analysis — complementary to the existing Larastan type analysis.
+# This project already runs Larastan for types, so Psalm is used here only for taint analysis
+# (dataflow security scanning), which PHPStan/Larastan cannot do.
+#
+# Psalm 6 runs taint in a separate mode (--taint-analysis skips type checks). It exits 0 even on
+# findings when writing a report under Actions, so CI is failed from the SARIF below, not the exit
+# code. Current findings are suppressed by psalm-baseline.xml (a taint-only baseline) so CI is green
+# from day one; only NEW taint findings fail the build.
+
+name: Psalm
+
+on:
+  push:
+    branches: [ 4.x ]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: psalm-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  taint-analysis:
+    name: Psalm taint analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Block unexpected egress
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          # Covers checkout, setup-php, Composer (public Packagist) and the SARIF upload. Extend for
+          # other hosts (private registry, VCS repos, extra plugins). Use egress-policy: audit to find them.
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            codeload.github.com:443
+            github.com:443
+            packagist.org:443
+            release-assets.githubusercontent.com:443
+            repo.packagist.org:443
+            results-receiver.actions.githubusercontent.com:443
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+
+      # Taint-only baseline suppresses today's findings; new ones surface. A taint-only baseline (no
+      # type entries) does not trip UnusedBaselineEntry in taint mode, so --use-baseline is safe here.
+      - name: Run Psalm (taint analysis)
+        run: ./vendor/bin/psalm --taint-analysis --use-baseline=psalm-baseline.xml --report=psalm.sarif --report-show-info=false
+
+      - name: Upload SARIF to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: psalm.sarif
+          category: psalm-taint
+
+      # Upload first so findings are recorded even on a failing run, then fail on any error-level finding.
+      - name: Fail on Psalm taint findings
+        run: |
+          errors=$(jq '[.runs[].results[] | select(.level == "error")] | length' psalm.sarif)
+          echo "Psalm taint findings: $errors"
+          if [ "$errors" -gt 0 ]; then
+            echo "::error::Psalm reported $errors taint finding(s). See annotations on Files changed (maintainers: Security > Code scanning)."
+            exit 1
+          fi

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
     "orchestra/testbench": "^9.0 | ^10.0",
     "pestphp/pest": "^4.0",
     "pestphp/pest-plugin-laravel": "^4.0",
+    "psalm/plugin-laravel": "^3",
     "rector/rector": "^2.0"
   },
   "replace": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
+  <file src="src/Admin/Classes/AdminController.php">
+    <TaintedCallable>
+      <code><![CDATA[[$this, $action]]]></code>
+      <code><![CDATA[[$widget, $handlerName]]]></code>
+      <code><![CDATA[[$widget, $handler]]]></code>
+    </TaintedCallable>
+  </file>
+  <file src="src/Admin/Traits/ControllerUtils.php">
+    <TaintedCallable>
+      <code><![CDATA[[$this, $handler]]]></code>
+      <code><![CDATA[[$this, $pageHandler]]]></code>
+      <code><![CDATA[[$this, $pageHandler]]]></code>
+    </TaintedCallable>
+  </file>
+  <file src="src/Admin/Widgets/Lists.php">
+    <TaintedSql>
+      <code><![CDATA[$sortColumn]]></code>
+    </TaintedSql>
+  </file>
+  <file src="src/Flame/Exception/FlashException.php">
+    <TaintedHtml>
+      <code><![CDATA[[
+                'X_IGNITER_FLASH_MESSAGES' => [$this->getContents()],
+            ]]]></code>
+    </TaintedHtml>
+  </file>
+  <file src="src/System/Classes/HubManager.php">
+    <TaintedHtml>
+      <code><![CDATA[$errors]]></code>
+    </TaintedHtml>
+  </file>
+  <file src="src/System/Classes/MailManager.php">
+    <TaintedHtml>
+      <code><![CDATA[html_entity_decode((string)preg_replace("/[\r\n]{2,}/", "\n\n", $text), ENT_QUOTES, 'UTF-8')]]></code>
+    </TaintedHtml>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<psalm
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="8"
+    findUnusedCode="false"
+    ensureOverrideAttribute="false"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="config"/>
+        <!-- composer require psalm/plugin-phpunit psalm/plugin-mockery for the full tests support -->
+        <!-- <directory name="tests"/>-->
+
+        <ignoreFiles allowMissingFiles="true">
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <plugins>
+        <!-- All Psalm Laravel options: https://github.com/psalm/psalm-plugin-laravel/blob/master/docs/config.md -->
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <resolveDynamicWhereClauses value="true" />
+            <findMissingTranslations value="false" />
+            <findMissingViews value="false" />
+        </pluginClass>
+    </plugins>
+
+    <issueHandlers>
+        <ClassMustBeFinal errorLevel="info"/>
+        <ImplicitToStringCast errorLevel="info"/>
+        <MissingClosureReturnType errorLevel="info"/>
+        <MissingImmutableAnnotation errorLevel="info"/>
+        <MissingOverrideAttribute errorLevel="info"/>
+        <RedundantCast errorLevel="info"/>
+        <RedundantCondition errorLevel="info"/>
+        <UnnecessaryVarAnnotation errorLevel="suppress"/>
+    </issueHandlers>
+
+    <forbiddenFunctions>
+        <function name="var_dump" />
+        <function name="dd" />
+    </forbiddenFunctions>
+</psalm>

--- a/src/System/Classes/UpdateManager.php
+++ b/src/System/Classes/UpdateManager.php
@@ -384,6 +384,7 @@ class UpdateManager
                 $this->configureComposerAuth(array_get($this->getCarteInfo(), 'email', ''));
             }
 
+            $outdatedItems = [];
             $composerLog = [];
             $this->composerManager->outdated(function($type, $line) use (&$outdatedItems, &$composerLog) {
                 if ($type === 'out') {


### PR DESCRIPTION
Hi! 👋 This is an unsolicited PR, so no pressure at all to take it — feel free to cherry-pick, adapt, or close it.

I was trying out [psalm-plugin-laravel](https://github.com/psalm/psalm-plugin-laravel) on a few well-maintained Laravel projects and ran it over TastyIgniter. Since you already use Larastan for type checking (good call), I didn't want to step on its toes — so this wires up Psalm for **only** the one thing PHPStan-based tools can't really do: taint analysis, i.e. following untrusted input across function boundaries into risky sinks (SQL, HTML/XSS, SSRF, shell, file paths, redirects). Think of it as a security-focused companion to Larastan rather than a replacement.

### What's in here

- Adds `psalm/plugin-laravel:^3` as a dev dependency. That's the stable line on Psalm 6, so there's **no `minimum-stability` change** to your `composer.json`.
- A `psalm.xml` from the plugin's `init` command, tuned for Laravel.
- A `psalm-baseline.xml` that baselines the **10** taint findings that exist today, so CI is green from the first commit. New findings will fail the build; the existing ones are there for you to look at whenever (I went through them — most are guarded framework dispatch or false positives; none looked exploitable to me).
- A single taint-only GitHub Actions job: pinned action SHAs, `harden-runner` egress control, results uploaded to Code Scanning, and a gate that only trips on *new* taint findings.

### One small extra

I also ran Psalm in type-analysis mode (not wired into CI here — that's Larastan's job), and it flagged `UpdateManager::fetchOutdatedItems()`: `$outdatedItems` is used by reference in the `outdated()` closure but never initialized (its sibling `$composerLog` right above it *is*), so a run where no `out` line comes back hits an undefined variable at `array_get()`. I added the one-line `$outdatedItems = []`. Totally fine to drop that hunk if you'd rather keep this PR purely additive.

### If you want to dig in

Taint results show up under **Security → Code scanning** with the full dataflow trace, and the 10 baselined entries are listed in `psalm-baseline.xml`. If you ever want Psalm's type analysis too (it overlaps Larastan), it's just `vendor/bin/psalm` locally.

Thanks for TastyIgniter — happy to adjust anything here or answer questions. Docs for the plugin: https://github.com/psalm/psalm-plugin-laravel
