### PR TITLE
Release v4.3.1

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,6 @@ use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddParamStringTypeFromSprintfUseRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\AddVoidReturnTypeWhereNoReturnRector;
-use Rector\TypeDeclaration\Rector\ClassMethod\StrictStringParamConcatRector;
 use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\Function_\AddFunctionVoidReturnTypeWhereNoReturnRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
@@ -45,9 +44,6 @@ return RectorConfig::configure()
         ],
         FunctionFirstClassCallableRector::class,
         SimplifyEmptyCheckOnEmptyArrayRector::class,
-        StrictStringParamConcatRector::class => [
-            __DIR__.'/src/Flame/Database/Concerns/HasRelationships.php',
-        ],
         SwitchNegatedTernaryRector::class,
         IssetOnPropertyObjectToPropertyExistsRector::class,
         NewlineBeforeNewAssignSetRector::class,

--- a/src/Admin/Classes/FilterScope.php
+++ b/src/Admin/Classes/FilterScope.php
@@ -69,8 +69,6 @@ class FilterScope
      *
      * @param string $type Specifies a render mode as described above
      * @param array $config A list of render mode specific config.
-     *
-     * @return $this
      */
     public function displayAs(string $type, array $config = []): self
     {

--- a/src/Admin/Classes/FormField.php
+++ b/src/Admin/Classes/FormField.php
@@ -171,8 +171,6 @@ class FormField
      *
      * @param ?string $type Specifies a render mode as described above
      * @param array $config A list of render mode specific config.
-     *
-     * @return $this
      */
     public function displayAs(?string $type, array $config = []): self
     {

--- a/src/Admin/Classes/ListColumn.php
+++ b/src/Admin/Classes/ListColumn.php
@@ -77,8 +77,6 @@ class ListColumn
      * - number - numeric column, aligned right
      *
      * @param string $type Specifies a render mode as described above
-     *
-     * @return $this
      */
     public function displayAs(?string $type, array $config = []): self
     {

--- a/src/Admin/Classes/MainMenuItem.php
+++ b/src/Admin/Classes/MainMenuItem.php
@@ -147,8 +147,6 @@ class MainMenuItem
      *
      * @param string $type Specifies a render mode as described above
      * @param array $config A list of render mode specific config.
-     *
-     * @return $this
      */
     public function displayAs($type, array $config = []): static
     {

--- a/src/Admin/Classes/ToolbarButton.php
+++ b/src/Admin/Classes/ToolbarButton.php
@@ -39,8 +39,6 @@ class ToolbarButton
      * - number - numeric column, aligned right
      *
      * @param string $type Specifies a render mode as described above
-     *
-     * @return $this
      */
     public function displayAs(string $type, array $config): static
     {

--- a/src/Flame/Database/Attach/HasMedia.php
+++ b/src/Flame/Database/Attach/HasMedia.php
@@ -217,7 +217,7 @@ trait HasMedia
     protected function handleHasMediaDeletion()
     {
         // only cascade soft deletes when configured
-        if (!(!$this->forceDeleting && static::hasGlobalScope(SoftDeletingScope::class))) {
+        if ($this->forceDeleting || !static::hasGlobalScope(SoftDeletingScope::class)) {
             $this->media()->get()->each->delete();
         }
     }

--- a/src/Flame/Database/Attach/Media.php
+++ b/src/Flame/Database/Attach/Media.php
@@ -594,8 +594,6 @@ class Media extends Model
 
     /**
      * @param string $name
-     *
-     * @return $this
      */
     public function forgetCustomProperty($name): static
     {

--- a/src/Flame/Database/Query/Builder.php
+++ b/src/Flame/Database/Query/Builder.php
@@ -65,7 +65,6 @@ class Builder extends IlluminateQueryBuilder
      *
      * @param DateTime|int $minutes
      * @param string $key
-     * @return $this
      */
     public function remember($minutes, $key = null): static
     {
@@ -79,7 +78,6 @@ class Builder extends IlluminateQueryBuilder
      * Indicate that the query results should be cached forever.
      *
      * @param string $key
-     * @return $this
      */
     public function rememberForever($key = null): static
     {
@@ -90,7 +88,6 @@ class Builder extends IlluminateQueryBuilder
      * Indicate that the results, if cached, should use the given cache tags.
      *
      * @param array|mixed $cacheTags
-     * @return $this
      */
     public function cacheTags($cacheTags): static
     {
@@ -314,7 +311,6 @@ class Builder extends IlluminateQueryBuilder
      * Clear memory cache for the given table.
      *
      * @param string|null $table
-     * @return $this
      */
     public function clearDuplicateCache($table = null): static
     {
@@ -325,8 +321,6 @@ class Builder extends IlluminateQueryBuilder
 
     /**
      * Flush the memory cache.
-     *
-     * @return $this
      */
     public function flushDuplicateCache(): static
     {
@@ -337,8 +331,6 @@ class Builder extends IlluminateQueryBuilder
 
     /**
      * Enable the memory cache on the query.
-     *
-     * @return $this
      */
     public function enableDuplicateCache(): static
     {
@@ -349,8 +341,6 @@ class Builder extends IlluminateQueryBuilder
 
     /**
      * Disable the memory cache on the query.
-     *
-     * @return $this
      */
     public function disableDuplicateCache(): static
     {

--- a/src/Flame/Database/Relations/MorphToMany.php
+++ b/src/Flame/Database/Relations/MorphToMany.php
@@ -78,8 +78,6 @@ class MorphToMany extends BelongsToMany
 
     /**
      * Set the where clause for the relation query.
-     *
-     * @return $this
      */
     #[Override]
     protected function addWhereConstraints(): static

--- a/src/Flame/Database/Traits/Validation.php
+++ b/src/Flame/Database/Traits/Validation.php
@@ -325,9 +325,8 @@ trait Validation
      * exists, otherwise return false.
      *
      * @param string $validationRule
-     * @return mixed
      */
-    protected function getPrepareRuleMethod($validationRule)
+    protected function getPrepareRuleMethod($validationRule): string|false
     {
         $method = 'prepare'.Str::studly($validationRule).'Rule';
 

--- a/src/Flame/Html/FormBuilder.php
+++ b/src/Flame/Html/FormBuilder.php
@@ -438,8 +438,6 @@ class FormBuilder
 
     /**
      * Set the session store implementation.
-     *
-     * @return $this
      */
     public function setSessionStore(Session $session): static
     {

--- a/src/Flame/Mail/Mailable.php
+++ b/src/Flame/Mail/Mailable.php
@@ -61,7 +61,6 @@ class Mailable extends MailableBase
      * Set the subject for the message.
      *
      * @param Message $message
-     * @return $this
      */
     #[Override]
     protected function buildSubject($message): self

--- a/src/Flame/Mixins/StringMixin.php
+++ b/src/Flame/Mixins/StringMixin.php
@@ -57,7 +57,7 @@ class StringMixin
      */
     public function getClassId()
     {
-        return function($name) {
+        return function($name): string {
             if (is_object($name)) {
                 $name = $name::class;
             }

--- a/src/Flame/Pagic/Exception/InvalidFileNameException.php
+++ b/src/Flame/Pagic/Exception/InvalidFileNameException.php
@@ -15,8 +15,6 @@ class InvalidFileNameException extends RuntimeException
 
     /**
      * Set the affected file name.
-     *
-     * @return $this
      */
     public function setInvalidFileName(string $invalidFileName): self
     {

--- a/src/Flame/Support/RouterHelper.php
+++ b/src/Flame/Support/RouterHelper.php
@@ -216,7 +216,7 @@ class RouterHelper
      * @param string $segment The segment definition.
      * @return ?string Returns the default value if it is provided. Returns false otherwise.
      */
-    public static function getSegmentDefaultValue($segment)
+    public static function getSegmentDefaultValue($segment): ?string
     {
         $optMarkerPos = mb_strpos($segment, '?');
         if ($optMarkerPos === false) {

--- a/src/System/Classes/UpdateManager.php
+++ b/src/System/Classes/UpdateManager.php
@@ -304,7 +304,7 @@ class UpdateManager
 
                 return PackageInfo::fromArray($installedPackageInfo);
             })
-            ->filter(fn(PackageInfo $packageInfo): bool => !($packageInfo->isCore() && $this->disableCoreUpdates))
+            ->filter(fn(PackageInfo $packageInfo): bool => !$packageInfo->isCore() || !$this->disableCoreUpdates)
             ->sortBy(fn(PackageInfo $packageInfo) => starts_with($packageInfo->package, 'tastyigniter/') ? 0 : 1)
             ->partition(fn(PackageInfo $packageInfo): bool => $this->isMarkedAsIgnored($packageInfo->code));
 


### PR DESCRIPTION
This release delivers important security hardening for template sandboxing and file uploads, along with a bug fix for active tab state management in admin forms.

## Fixed

- Active tab now resets to the default when opening a new or different record, preventing stale tab state from carrying over between records
- Hardened file upload handling to protect against path traversal and code injection attacks
- Blocked higher-order function bypass attempts in the Pagic template sandbox
- Blocked server-side template injection in mail and theme templates

## Changed

- Simplified sandbox regex patterns and callback syntax in Pagic for cleaner, more maintainable code

## Security

- **Restricted `@php` Blade directive in layouts.** Default layouts no longer permit raw `@php` blocks to prevent unsanitised input execution.
  - If you haven't customised the default layout: no action needed, the update applies automatically.
  - If you have customised the default layout: back up your current layout, delete the existing default layout (so the updated version can be regenerated), then reapply your customisations on top of the new default.
- **Theme and mail layout editors now validate against raw PHP.** If you need PHP in a theme or mail layout, edit the Blade files directly on disk — the in-app theme/mail editors will reject saves containing PHP code.
