### PR TITLE
Add optional auto-refresh interval to the admin Lists widget

### DIFF
--- a/resources/js/widgets/lists.js
+++ b/resources/js/widgets/lists.js
@@ -58,3 +58,59 @@ $(function ($) {
         $('[data-action-select-all]').prop('disabled', true)
     }
 });
+
+// List auto-refresh
+$(function ($) {
+    var pendingRequests = {}
+
+    $('[data-list-refresh-interval]').each(function () {
+        var id = $(this).attr('id'),
+            interval = parseInt($(this).data('list-refresh-interval'), 10),
+            handler = $(this).data('list-refresh-handler')
+
+        if (!id || !interval || !handler)
+            return;
+
+        scheduleRefresh(id, handler, interval * 1000)
+    })
+
+    // A fresh lookup by id is required on every tick because onRefresh
+    // replaces the list root element (~#id), leaving any cached
+    // jQuery object referencing a detached node.
+    function scheduleRefresh(id, handler, delay) {
+        setTimeout(function () {
+            var $list = $('#' + id)
+
+            if (!$list.length)
+                return;
+
+            if (shouldSkipRefresh(id, $list)) {
+                scheduleRefresh(id, handler, delay)
+                return;
+            }
+
+            pendingRequests[id] = true
+            $list.request(handler).always(function () {
+                pendingRequests[id] = false
+                scheduleRefresh(id, handler, delay)
+            })
+        }, delay)
+    }
+
+    function shouldSkipRefresh(id, $list) {
+        if (document.visibilityState !== 'visible')
+            return true;
+
+        if (pendingRequests[id])
+            return true;
+
+        if ($list.find('input[name*=checked]:checked').length)
+            return true;
+
+        var $activePage = $list.find('.page-item.active .page-link')
+        if ($activePage.length && $.trim($activePage.first().text()) !== '1')
+            return true;
+
+        return false;
+    }
+});

--- a/resources/js/widgets/lists.js
+++ b/resources/js/widgets/lists.js
@@ -108,7 +108,7 @@ $(function ($) {
             return true;
 
         var $activePage = $list.find('.page-item.active .page-link')
-        if ($activePage.length && $.trim($activePage.first().text()) !== '1')
+        if ($activePage.length && $activePage.first().text().trim() !== '1')
             return true;
 
         return false;

--- a/resources/views/admin/_partials/widgets/lists/list.blade.php
+++ b/resources/views/admin/_partials/widgets/lists/list.blade.php
@@ -1,5 +1,9 @@
 <div
     id="{{ $this->getId('list') }}"
+    @if ($refreshInterval > 0)
+        data-list-refresh-interval="{{ $refreshInterval }}"
+        data-list-refresh-handler="{{ $this->getEventHandler('onRefresh') }}"
+    @endif
 >
     {!! form_open([
         'id' => $this->getId('list-form'),

--- a/src/Admin/Widgets/Lists.php
+++ b/src/Admin/Widgets/Lists.php
@@ -68,6 +68,9 @@ class Lists extends BaseWidget
     /** A default sort column to look for. */
     public null|string|array $defaultSort = null;
 
+    /** Seconds between automatic list refreshes. 0 disables auto-refresh. */
+    public int $refreshInterval = 0;
+
     protected string $defaultAlias = 'list';
 
     /** Collection of all list columns used in this list. */
@@ -132,6 +135,7 @@ class Lists extends BaseWidget
             'showCheckboxes',
             'showSorting',
             'defaultSort',
+            'refreshInterval',
         ]);
 
         $this->pageLimit = $this->getSession('page_limit', $this->pageLimit ?? 20);
@@ -172,6 +176,7 @@ class Lists extends BaseWidget
         $this->vars['showSorting'] = $this->showSorting;
         $this->vars['sortColumn'] = $this->getSortColumn();
         $this->vars['sortDirection'] = $this->sortDirection;
+        $this->vars['refreshInterval'] = $this->refreshInterval;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds a `refreshInterval` config option (seconds; `0` = disabled, the default) to the `Lists` widget.
- When set, the list root renders `data-list-refresh-interval`/`data-list-refresh-handler` attributes, and a JS polling loop periodically calls the existing `onRefresh` AJAX handler to swap in fresh rows.
- Polling pauses when the tab is hidden, rows are selected, the list isn't on page 1, or a refresh is already in flight.
- Companion to tastyigniter/ti-ext-cart#(orders auto-refresh setting), which is the first consumer of this option.

## Test plan
- [ ] `refreshInterval` renders the data attributes when > 0, and omits them at the default 0