### PR TITLE
Fix empty place suggestion titles for plain addresses (Nominatim provider)

### DIFF
--- a/src/Flame/Geolite/Provider/NominatimProvider.php
+++ b/src/Flame/Geolite/Provider/NominatimProvider.php
@@ -139,7 +139,7 @@ class NominatimProvider extends AbstractProvider
 
             return collect($result)->map(fn($item) => (new Place)
                 ->placeId((string)$item->place_id)
-                ->title((string)$item->name)
+                ->title((string)(($item->name ?? '') ?: $item->display_name))
                 ->description((string)$item->display_name)
                 ->provider('nominatim')
                 ->withData('osmType', $item->osm_type)

--- a/tests/src/Flame/Geolite/Provider/NominatimProviderTest.php
+++ b/tests/src/Flame/Geolite/Provider/NominatimProviderTest.php
@@ -240,6 +240,30 @@ it('returns places autocomplete results when query is successful', function() {
         ->and($result->first()->toArray())->toHaveKeys(['placeId', 'title', 'description', 'provider', 'data']);
 });
 
+it('falls back to display_name for places autocomplete title when name is empty', function() {
+    $response = mock(ResponseInterface::class);
+    $response->shouldReceive('getStatusCode')->andReturn(200);
+    $response->shouldReceive('getBody->getContents')->andReturn(json_encode([
+        [
+            'place_id' => 'place_id_456',
+            'name' => '',
+            'display_name' => '76, Bochumer Strasse, Obercastrop, Castrop-Rauxel, 44575, Deutschland',
+            'osm_type' => 'way',
+            'osm_id' => '155198850',
+            'category' => 'building',
+            'lat' => 51.5414797,
+            'lon' => 7.3082737,
+        ],
+    ]));
+    $this->httpClient->shouldReceive('get')->andReturn($response);
+    $query = new GeoQuery('bochumer str 76 castrop-rauxel');
+
+    $result = $this->provider->placesAutocomplete($query);
+    expect($result)->toHaveCount(1)
+        ->and($result->first()->getTitle())->toBe('76, Bochumer Strasse, Obercastrop, Castrop-Rauxel, 44575, Deutschland')
+        ->and($result->first()->getDescription())->toBe('76, Bochumer Strasse, Obercastrop, Castrop-Rauxel, 44575, Deutschland');
+});
+
 it('returns empty coordinates when places coordinates query fails', function() {
     $response = mock(ResponseInterface::class);
     $response->shouldReceive('getStatusCode')->andReturn(500);


### PR DESCRIPTION
## The bug

`NominatimProvider::placesAutocomplete()` maps the suggestion title from Nominatim's `name` field:

```php
->title((string)$item->name)
```

Nominatim only populates `name` for named POIs (restaurants, landmarks). For plain street addresses — which is what delivery customers type — `name` is an empty string, so the suggestion title is blank.

## User-facing impact

In `ti-theme-orange`, `SearchesNearby::onSelectSuggestion()` writes the selected suggestion's title back into `searchQuery`. With a blank title the query becomes empty, and `FulfillmentModal::onConfirm()` then silently skips the address branch (`if ($this->searchQuery && $this->showAddressPicker)`) — no validation error, no stored user position. The customer believes they set their delivery address; checkout shows **"No delivery address provided"**.

This affects every install using the default/free Nominatim geocoder (no Google API key).

**Repro:** guest visitor → fulfillment modal → delivery → type a street address with house number (e.g. `Bochumer Str. 76, Castrop-Rauxel`) → select the suggestion → input blanks → Confirm → checkout has no delivery address.

## The fix

Fall back to `display_name` when `name` is empty. `display_name` is guaranteed non-empty and — being Nominatim's own output — re-geocodes cleanly when `onConfirm()` geocodes the title verbatim. Named POIs keep their `name` as before (existing test still passes).

Test added; full `NominatimProviderTest` + `GoogleProviderTest` suite passes (27 assertions).