### PR TITLE
Release v4.3.3

### DIFF
--- a/resources/lang/en/system.php
+++ b/resources/lang/en/system.php
@@ -440,6 +440,8 @@ return [
             'session_driver' => 'Session',
             'cache_driver' => 'Cache',
             'mail_driver' => 'Mail',
+            'app_timezone' => 'Application timezone',
+            'app_datetime' => 'Application date/time',
             'config_drivers' => 'Configuration Drivers',
             'config_drivers_ok' => 'Application drivers configured.',
             'driver' => 'Driver',

--- a/src/Flame/Composer/Manager.php
+++ b/src/Flame/Composer/Manager.php
@@ -234,14 +234,12 @@ class Manager
     {
         $config = new JsonConfigSource(new JsonFile($this->workingPath.'/auth.json'), true);
 
-        $config->addConfigSetting('http-basic.'.self::REPOSITORY_HOST, [
-            'username' => $carteUsername,
-            'password' => $carteKey,
-        ]);
-
         $config->addConfigSetting(
             'custom-headers.'.self::REPOSITORY_HOST,
-            SystemHelper::composerHeaderLines($installationUrl)
+            array_merge(
+                ['TI-Rest-Key: '.$carteKey],
+                SystemHelper::composerHeaderLines($installationUrl),
+            ),
         );
     }
 

--- a/src/Flame/Support/Igniter.php
+++ b/src/Flame/Support/Igniter.php
@@ -13,7 +13,7 @@ use Illuminate\View\Factory;
 
 class Igniter
 {
-    protected const string VERSION = 'v4.3.2';
+    protected const string VERSION = 'v4.3.3';
 
     /**
      * The base path for extensions.

--- a/src/System/Health/Checks/ApplicationCheck.php
+++ b/src/System/Health/Checks/ApplicationCheck.php
@@ -52,11 +52,14 @@ class ApplicationCheck extends Check
      *     sessionDriver: string,
      *     cacheDriver: string,
      *     mailDriver: string,
+     *     appTimezone: string,
+     *     appDatetime: string,
      * }
      */
     protected function context(): array
     {
         $databaseConnection = (string) config('database.default');
+        $appTimezone = date_default_timezone_get();
 
         return [
             'version' => Igniter::version(),
@@ -66,6 +69,8 @@ class ApplicationCheck extends Check
             'sessionDriver' => (string) config('session.driver'),
             'cacheDriver' => (string) config('cache.default'),
             'mailDriver' => (string) config('mail.default'),
+            'appTimezone' => $appTimezone,
+            'appDatetime' => now()->timezone($appTimezone)->format('Y-m-d H:i:s T'),
         ];
     }
 
@@ -78,6 +83,8 @@ class ApplicationCheck extends Check
      *     sessionDriver: string,
      *     cacheDriver: string,
      *     mailDriver: string,
+     *     appTimezone: string,
+     *     appDatetime: string,
      * }  $context
      * @return array<string, array{value: string, status: string}|string>
      */
@@ -102,6 +109,8 @@ class ApplicationCheck extends Check
             lang('igniter::system.system.checks.session_driver') => $context['sessionDriver'],
             lang('igniter::system.system.checks.cache_driver') => $context['cacheDriver'],
             lang('igniter::system.system.checks.mail_driver') => $context['mailDriver'],
+            lang('igniter::system.system.checks.app_timezone') => $context['appTimezone'],
+            lang('igniter::system.system.checks.app_datetime') => $context['appDatetime'],
         ];
     }
 
@@ -114,6 +123,8 @@ class ApplicationCheck extends Check
      *     sessionDriver: string,
      *     cacheDriver: string,
      *     mailDriver: string,
+     *     appTimezone: string,
+     *     appDatetime: string,
      * }  $context
      * @param  array<string, array{value: string, status: string}|string>  $meta
      * @return array<int, array{status: string, summary: string, action: string, actionUrl?: string, actionUrlLabel?: string}>

--- a/src/System/Health/MediaPhpExecutionProbe.php
+++ b/src/System/Health/MediaPhpExecutionProbe.php
@@ -37,7 +37,7 @@ class MediaPhpExecutionProbe
         $token = 'ti-health-probe-'.bin2hex(random_bytes(8));
 
         try {
-            if (!File::put($probePath, '<?php echo \''.$token.'\';')) {
+            if (!File::put($probePath, "<?php echo '".$token."';")) {
                 return [
                     'status' => 'unverified',
                     'summary' => lang('igniter::system.system.checks.web_server_security_probe_not_writable'),
@@ -46,7 +46,7 @@ class MediaPhpExecutionProbe
 
             $response = $this->httpClient()->get($url);
 
-            if (str_contains($response->body(), $token)) {
+            if (str_contains((string) $response->body(), $token)) {
                 return [
                     'status' => 'vulnerable',
                     'summary' => lang('igniter::system.system.checks.web_server_security_probe_vulnerable'),

--- a/tests/src/Flame/Composer/ManagerTest.php
+++ b/tests/src/Flame/Composer/ManagerTest.php
@@ -229,9 +229,9 @@ it('adds marketplace auth credentials and installation header to auth json', fun
     $manager->addMarketplaceAuth('tastyigniter', 'carte-key');
 
     $config = json_decode(file_get_contents(base_path('auth.json')), true);
-    expect($config['http-basic']['composer.tastyigniter.com']['username'])->toBe('tastyigniter')
-        ->and($config['http-basic']['composer.tastyigniter.com']['password'])->toBe('carte-key')
+    expect($config)->not->toHaveKey('http-basic')
         ->and($config['custom-headers']['composer.tastyigniter.com'])->toBe([
+            'TI-Rest-Key: carte-key',
             'X-Igniter-Platform: php:'.PHP_VERSION.';version:'.Igniter::version().';url:https://example.com',
         ]);
 


### PR DESCRIPTION
## Changed

- Marketplace Composer authentication — Carte key is now sent via the TI-Rest-Key custom header instead of HTTP Basic auth, so platform headers are included on marketplace requests.

**Upgrade note:** After updating, retry an extension update via the admin updates so auth.json is regenerated without the old http-basic entry for composer.tastyigniter.com.
