### PR TITLE
Release v4.3.4

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,10 @@
 name: Core CI Pipeline
 
-on: [ push, workflow_dispatch ]
+on:
+  push:
+    branches:
+      - 4.x
+  workflow_dispatch:
 
 jobs:
   build-assets:

--- a/src/Flame/Geolite/Provider/NominatimProvider.php
+++ b/src/Flame/Geolite/Provider/NominatimProvider.php
@@ -139,7 +139,7 @@ class NominatimProvider extends AbstractProvider
 
             return collect($result)->map(fn($item) => (new Place)
                 ->placeId((string)$item->place_id)
-                ->title((string)$item->name)
+                ->title((string)(($item->name ?? '') ?: $item->display_name))
                 ->description((string)$item->display_name)
                 ->provider('nominatim')
                 ->withData('osmType', $item->osm_type)

--- a/src/Flame/Pagic/TemplateSandbox.php
+++ b/src/Flame/Pagic/TemplateSandbox.php
@@ -11,9 +11,12 @@ class TemplateSandbox
     protected const array ALLOWED_DIRECTIVES = [
         'if', 'elseif', 'else', 'endif',
         'foreach', 'endforeach',
+        'forelse', 'endforelse',
         'isset', 'endisset',
         'empty', 'endempty',
         'unless', 'endunless',
+        'switch', 'case', 'default', 'endswitch',
+        'break', 'continue',
         'partial', 'endpartial',
         'lang', 'choice',
     ];
@@ -39,6 +42,38 @@ class TemplateSandbox
         'getenv', 'putenv', 'env', 'ini_set', 'curl_exec', 'curl_init', 'curl_setopt',
         'fsockopen', 'define', 'extract', 'parse_str', 'chr', 'preg_replace',
     ];
+
+    protected const array ALLOWED_METHODS = [
+        'getthumb', 'getthumborblank', 'getpath', 'geturl',
+    ];
+
+    /** @var array<int, string> */
+    protected array $registeredFunctions = [];
+
+    /** @var array<int, string> */
+    protected array $registeredMethods = [];
+
+    /**
+     * @param array<int, string> $functions
+     */
+    public function registerAllowedFunctions(array $functions): void
+    {
+        $this->registeredFunctions = array_merge(
+            $this->registeredFunctions,
+            array_map(strtolower(...), $functions),
+        );
+    }
+
+    /**
+     * @param array<int, string> $methods
+     */
+    public function registerAllowedMethods(array $methods): void
+    {
+        $this->registeredMethods = array_merge(
+            $this->registeredMethods,
+            array_map(strtolower(...), $methods),
+        );
+    }
 
     public function assertSafe(string $template, SandboxProfile $profile = SandboxProfile::Mail): void
     {
@@ -211,11 +246,17 @@ class TemplateSandbox
 
     protected function validateUnescapedExpression(string $expression): ?string
     {
-        if (!preg_match('/^\$[a-zA-Z_]\w*(\s*\[(?:\'[^\']*\'|"[^"]*")\])?$/', trim($expression))) {
-            return 'Unescaped output may only reference simple variables';
+        $expression = trim($expression);
+
+        if (preg_match('/^\$[a-zA-Z_]\w*(\s*\[(?:\'[^\']*\'|"[^"]*")\])?$/', $expression)) {
+            return null;
         }
 
-        return null;
+        if ($this->validateExpression($expression, true) === null) {
+            return null;
+        }
+
+        return 'Unescaped output may only reference simple variables or safe expressions';
     }
 
     protected function validateExpression(string $expression, bool $unescaped): ?string
@@ -236,8 +277,8 @@ class TemplateSandbox
             return 'Static calls are not allowed';
         }
 
-        if (str_contains($scan, '->')) {
-            return 'Object method calls are not allowed';
+        if (str_contains($scan, '->') && $violation = $this->validateObjectMethodCalls($scan)) {
+            return $violation;
         }
 
         if (preg_match('/\bnew\s+/i', $scan)) {
@@ -280,23 +321,77 @@ class TemplateSandbox
             return 'Reflection is not allowed';
         }
 
-        if (!preg_match_all('/\b([a-zA-Z_]\w*)\s*\(/', $scan, $functionMatches)) {
+        if (!preg_match_all('/\b([a-zA-Z_]\w*)\s*\(/', $scan, $functionMatches, PREG_OFFSET_CAPTURE)) {
             return null;
         }
 
-        foreach ($functionMatches[1] as $function) {
+        foreach ($functionMatches[1] as $index => $functionMatch) {
+            $function = $functionMatch[0];
+            $offset = $functionMatches[0][$index][1];
+            $before = substr($scan, 0, $offset);
+
+            if (preg_match('/->\s*$/', rtrim($before))) {
+                continue;
+            }
+
             $functionLower = strtolower($function);
 
             if (in_array($functionLower, self::DANGEROUS_FUNCTIONS, true)) {
                 return 'Forbidden function: '.$function;
             }
 
-            if (!in_array($functionLower, self::ALLOWED_FUNCTIONS, true)) {
+            if (!in_array($functionLower, $this->getAllowedFunctions(), true)) {
                 return 'Disallowed function: '.$function;
             }
         }
 
         return null;
+    }
+
+    protected function validateObjectMethodCalls(string $scan): ?string
+    {
+        if (!preg_match_all(
+            '/(\$[a-zA-Z_]\w*(?:\s*\[(?:\'[^\']*\'|"[^"]*")\])?)\s*->\s*([a-zA-Z_]\w*)\s*\(/',
+            $scan,
+            $matches,
+            PREG_SET_ORDER,
+        )) {
+            return 'Object method calls are not allowed';
+        }
+
+        $remaining = $scan;
+
+        foreach ($matches as $match) {
+            $methodLower = strtolower($match[2]);
+
+            if (!in_array($methodLower, $this->getAllowedMethods(), true)) {
+                return 'Disallowed object method: '.$match[2];
+            }
+
+            $remaining = str_replace($match[0], '$__safe__', $remaining);
+        }
+
+        if (str_contains($remaining, '->')) {
+            return 'Object method calls are not allowed';
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getAllowedFunctions(): array
+    {
+        return array_values(array_unique(array_merge(self::ALLOWED_FUNCTIONS, $this->registeredFunctions)));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function getAllowedMethods(): array
+    {
+        return array_values(array_unique(array_merge(self::ALLOWED_METHODS, $this->registeredMethods)));
     }
 
     protected function stripStringLiterals(string $expression): string

--- a/src/Flame/Support/Helpers/helpers.php
+++ b/src/Flame/Support/Helpers/helpers.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 /**
  * Igniter System Helpers
  */
-
 use Carbon\Carbon;
 use Igniter\Admin\Helpers\AdminHelper;
 use Igniter\Flame\Currency\Currency;
 use Igniter\Flame\Currency\Facades\Currency as CurrencyFacade;
+use Igniter\Flame\Database\Attach\Media;
 use Igniter\Flame\Flash\FlashBag;
 use Igniter\Flame\Support\StringParser;
 use Igniter\Local\Models\Location;
@@ -484,9 +484,13 @@ if (!function_exists('media_thumb')) {
      * Media thumbnail
      * Returns the full thumbnail (including segments) of the assets media uploads directory
      */
-    function media_thumb(?string $path, array $options = []): string
+    function media_thumb(mixed $path, array $options = []): string
     {
-        return ImageHelper::resize($path ?? 'no_photo.png', $options);
+        if ($path instanceof Media) {
+            return $path->getThumb($options);
+        }
+
+        return ImageHelper::resize(is_string($path) ? $path : 'no_photo.png', $options);
     }
 }
 

--- a/src/Flame/Support/Igniter.php
+++ b/src/Flame/Support/Igniter.php
@@ -13,7 +13,7 @@ use Illuminate\View\Factory;
 
 class Igniter
 {
-    protected const string VERSION = 'v4.3.3';
+    protected const string VERSION = 'v4.3.4';
 
     /**
      * The base path for extensions.

--- a/src/System/Classes/MailManager.php
+++ b/src/System/Classes/MailManager.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Igniter\System\Classes;
 
-use Igniter\Flame\Pagic\SandboxProfile;
 use Igniter\Flame\Pagic\TemplateSandbox;
 use Igniter\Flame\Support\StringParser;
 use Igniter\System\Models\MailPartial;
@@ -146,7 +145,6 @@ class MailManager
     {
         $this->registerBladeDirectives();
 
-        $content = resolve(TemplateSandbox::class)->sanitize($content, SandboxProfile::Mail);
         $content = Blade::render($content, $data);
 
         return new HtmlString((new StringParser)->parse($content, $data));
@@ -294,6 +292,26 @@ class MailManager
         }
 
         $this->registeredVariables = $definitions + $this->registeredVariables;
+    }
+
+    /**
+     * Registers additional safe functions for mail template validation.
+     *
+     * @param array<int, string> $functions
+     */
+    public function registerMailTemplateFunctions(array $functions): void
+    {
+        resolve(TemplateSandbox::class)->registerAllowedFunctions($functions);
+    }
+
+    /**
+     * Registers additional safe object methods for mail template validation.
+     *
+     * @param array<int, string> $methods
+     */
+    public function registerMailTemplateMethods(array $methods): void
+    {
+        resolve(TemplateSandbox::class)->registerAllowedMethods($methods);
     }
 
     /**

--- a/tests/src/Flame/Geolite/Provider/NominatimProviderTest.php
+++ b/tests/src/Flame/Geolite/Provider/NominatimProviderTest.php
@@ -240,6 +240,30 @@ it('returns places autocomplete results when query is successful', function() {
         ->and($result->first()->toArray())->toHaveKeys(['placeId', 'title', 'description', 'provider', 'data']);
 });
 
+it('falls back to display_name for places autocomplete title when name is empty', function() {
+    $response = mock(ResponseInterface::class);
+    $response->shouldReceive('getStatusCode')->andReturn(200);
+    $response->shouldReceive('getBody->getContents')->andReturn(json_encode([
+        [
+            'place_id' => 'place_id_456',
+            'name' => '',
+            'display_name' => '76, Bochumer Strasse, Obercastrop, Castrop-Rauxel, 44575, Deutschland',
+            'osm_type' => 'way',
+            'osm_id' => '155198850',
+            'category' => 'building',
+            'lat' => 51.5414797,
+            'lon' => 7.3082737,
+        ],
+    ]));
+    $this->httpClient->shouldReceive('get')->andReturn($response);
+    $query = new GeoQuery('bochumer str 76 castrop-rauxel');
+
+    $result = $this->provider->placesAutocomplete($query);
+    expect($result)->toHaveCount(1)
+        ->and($result->first()->getTitle())->toBe('76, Bochumer Strasse, Obercastrop, Castrop-Rauxel, 44575, Deutschland')
+        ->and($result->first()->getDescription())->toBe('76, Bochumer Strasse, Obercastrop, Castrop-Rauxel, 44575, Deutschland');
+});
+
 it('returns empty coordinates when places coordinates query fails', function() {
     $response = mock(ResponseInterface::class);
     $response->shouldReceive('getStatusCode')->andReturn(500);

--- a/tests/src/Flame/Pagic/TemplateSandboxTest.php
+++ b/tests/src/Flame/Pagic/TemplateSandboxTest.php
@@ -50,7 +50,29 @@ it('accepts safe mail template expressions', function(): void {
     $this->sandbox->assertSafe('@if(!empty($order_menus))@foreach($order_menus as $order_menu){{ $order_menu[\'menu_name\'] }}@endforeach@endif', SandboxProfile::Mail);
     $this->sandbox->assertSafe("@lang('igniter.orange::default.button_back')", SandboxProfile::Mail);
     $this->sandbox->assertSafe("{{ lang('igniter.orange::default.button_back') }}", SandboxProfile::Mail);
-});
+    $this->sandbox->assertSafe('{{ $location_logo->getThumb([\'height\' => 56]) }}', SandboxProfile::Mail);
+    $this->sandbox->assertSafe('{{ media_thumb($location_logo, [\'height\' => 56]) }}', SandboxProfile::Mail);
+    $this->sandbox->assertSafe('@forelse($order_menus as $order_menu){{ $order_menu[\'menu_name\'] }}@empty<p>No items</p>@endforelse', SandboxProfile::Mail);
+    $this->sandbox->assertSafe('@switch($order_type)@case(\'delivery\')Delivery@break@default Collection@endswitch', SandboxProfile::Mail);
+})->throwsNoExceptions();
+
+it('rejects unsafe object method calls in mail templates', function(string $payload): void {
+    expect(fn() => $this->sandbox->assertSafe($payload, SandboxProfile::Mail))
+        ->toThrow(SystemException::class);
+})->with([
+    '{{ $location_logo->delete() }}',
+    '{{ $order->location->getThumb() }}',
+    '{{ app("db")->getThumb() }}',
+]);
+
+it('allows extension registered mail template functions and methods', function(): void {
+    $sandbox = new TemplateSandbox;
+    $sandbox->registerAllowedFunctions(['currency_format']);
+    $sandbox->registerAllowedMethods(['formatCurrency']);
+
+    $sandbox->assertSafe('{{ currency_format($total) }}', SandboxProfile::Mail);
+    $sandbox->assertSafe('{{ $order->formatCurrency() }}', SandboxProfile::Mail);
+})->throwsNoExceptions();
 
 it('still rejects static calls outside string literals', function(): void {
     expect(fn() => $this->sandbox->assertSafe('{{ \\Class::method() }}', SandboxProfile::Mail))
@@ -84,7 +106,7 @@ it('strips higher-order function bypass payloads from theme templates', function
 
 it('allows safe unescaped output in mail profile', function(): void {
     $this->sandbox->assertSafe('{!! $body !!}', SandboxProfile::Mail);
-});
+})->throwsNoExceptions();
 
 it('neutralizes poisoned mail templates during sanitize', function(): void {
     $sanitized = $this->sandbox->sanitize('{{ shell_exec("id") }} safe {{ $name }}', SandboxProfile::Mail);

--- a/tests/src/System/Classes/MailManagerTest.php
+++ b/tests/src/System/Classes/MailManagerTest.php
@@ -10,15 +10,6 @@ use Igniter\System\Models\MailTemplate;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 
-it('neutralizes poisoned template content before rendering', function(): void {
-    $manager = resolve(MailManager::class);
-
-    $result = $manager->renderView('{{ shell_exec("id") }} Hello {{ $name }}', ['name' => 'World']);
-
-    expect($result->toHtml())->toBe('Hello World')
-        ->and($result->toHtml())->not->toContain('shell_exec');
-});
-
 it('renders mail templates', function() {
     $manager = resolve(MailManager::class);
     $template = $manager->getTemplate('_mail.test_template');


### PR DESCRIPTION
This release expands the template sandbox capabilities and fixes an issue with empty place suggestion titles for plain addresses.

## Added

- Template sandbox now supports allowlisted object methods and extensible registries, giving greater flexibility when working with sandboxed templates

## Fixed

- Empty place suggestion titles for plain addresses when using the Nominatim provider are now handled correctly