### PR TITLE
fix: bind the checkboxlist select all/none links

### DIFF
--- a/resources/js/widgets/formwidget.js
+++ b/resources/js/widgets/formwidget.js
@@ -30,7 +30,20 @@
 
     FormWidget.prototype.registerHandlers = function () {
         this.$formTabs.on('show.bs.tab', 'a[data-bs-toggle="tab"]', $.proxy(this.onTabShown, this))
+        this.$el.on('click', '[data-field-checkboxlist-all], [data-field-checkboxlist-none]', $.proxy(this.onCheckboxListToggle, this))
     };
+
+    FormWidget.prototype.onCheckboxListToggle = function (event) {
+        event.preventDefault()
+
+        var $link = $(event.currentTarget),
+            checked = $link.is('[data-field-checkboxlist-all]')
+
+        $link.closest('.field-checkboxlist')
+            .find('input[type="checkbox"]:not(:disabled)')
+            .prop('checked', checked)
+            .trigger('change')
+    }
 
     FormWidget.prototype.dispose = function () {
         this.unbindDependants()


### PR DESCRIPTION
## The bug

`resources/views/admin/_partials/widgets/form/field_checkboxlist.blade.php` renders "select all" / "select none" anchors for any checkboxlist with more than 10 options:

```blade
<a href="javascript:;" data-field-checkboxlist-all>@lang('igniter::admin.text_select_all')</a>,
<a href="javascript:;" data-field-checkboxlist-none>@lang('igniter::admin.text_select_none')</a>
```

but nothing anywhere in the codebase binds `data-field-checkboxlist-all` / `data-field-checkboxlist-none` — a repo-wide grep matches only the Blade partial itself (checked at current `4.x` HEAD, v4.3.4). Clicking the links does nothing on any admin form; they appear to have been left behind in the v4 rewrite.

## The fix

A delegated click handler on the form widget (`resources/js/widgets/formwidget.js`), matching the widget's existing handler style: it toggles all non-disabled checkboxes inside the enclosing `.field-checkboxlist` and fires `change` so `dependsOn`-style bindings react to the new state. Delegation from the widget element keeps it working for fields on any tab.

Source-only change — no rebuilt `public/js` included, following the pattern of #64 (happy to add the compiled assets if you prefer PRs to include them).

## How to reproduce / verify

1. Any admin form field of `type: checkboxlist` with >10 options (so `$isScrollable` renders the links).
2. Before: clicking "select all" / "select none" does nothing.
3. After: all enabled checkboxes in that list check/uncheck, and dependent fields refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)