### PR TITLE
fix: accept numeric input in the configured currency format

### DIFF
--- a/resources/views/admin/_partials/widgets/form/field_currency.blade.php
+++ b/resources/views/admin/_partials/widgets/form/field_currency.blade.php
@@ -4,6 +4,8 @@ $symbolAfter = $currencyModel?->getSymbolPosition();
 $symbol = $currencyModel?->getSymbol();
 $decimalSign = $currencyModel?->decimal_sign ?? '.';
 $decimalPosition = $currencyModel?->decimal_position ?? 2;
+// the pattern must accept the same decimal sign the value is rendered with
+$inputPattern = $decimalSign === '.' ? '-?\d+(\.\d+)?' : '-?\d+([\.'.$decimalSign.']\d+)?';
 @endphp
 @if ($this->previewMode)
     <p class="form-control-static">{{ $field->value ? currency_format($field->value) : '0' }}</p>
@@ -22,7 +24,7 @@ $decimalPosition = $currencyModel?->decimal_position ?? 2;
             placeholder="@lang($field->placeholder)"
             autocomplete="off"
             step="any"
-            {!! $field->hasAttribute('pattern') ? '' : 'pattern="-?\d+(\.\d+)?"' !!}
+            {!! $field->hasAttribute('pattern') ? '' : 'pattern="'.$inputPattern.'"' !!}
             {!! $field->hasAttribute('maxlength') ? '' : 'maxlength="255"' !!}
             {!! $field->getAttributes() !!}
         />

--- a/src/System/Classes/FormRequest.php
+++ b/src/System/Classes/FormRequest.php
@@ -6,6 +6,7 @@ namespace Igniter\System\Classes;
 
 use Igniter\Flame\Traits\EventEmitter;
 use Igniter\System\Helpers\ValidationHelper;
+use Igniter\System\Models\Currency;
 use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest as BaseFormRequest;
@@ -33,6 +34,8 @@ class FormRequest extends BaseFormRequest
         $dataHolder->messages = array_merge(Arr::get($parsedRules, 'messages', []), $this->messages());
         $dataHolder->attributes = array_merge(Arr::get($parsedRules, 'attributes', []), $this->attributes());
 
+        $dataHolder->data = $this->normalizeCurrencyFormattedNumbers($dataHolder->data, $dataHolder->rules);
+
         $this->fireSystemEvent('system.formRequest.extendValidator', [$dataHolder]);
 
         return $factory->make(
@@ -56,5 +59,55 @@ class FormRequest extends BaseFormRequest
     {
         return ($slug = $this->route('slug'))
             ? str_after($slug, '/') : null;
+    }
+
+    /**
+     * Accept numeric input in the format the admin renders it in.
+     *
+     * The currency form field displays values using the default currency's
+     * decimal/thousand signs ("11,50" or "1.234,56" when the decimal sign is
+     * a comma), but the `numeric` rule only accepts machine format — so the
+     * field renders a value its own form refuses to save. Convert values
+     * matching the configured currency format back to machine format for
+     * every explicitly `numeric`-validated field, before the validator is
+     * built. No-op when the configured decimal sign is already a dot, so
+     * nothing changes for default installs.
+     */
+    protected function normalizeCurrencyFormattedNumbers(array $data, array $rules): array
+    {
+        $decimalSign = ($currency = Currency::getDefault())?->decimal_sign ?: '.';
+        if ($decimalSign === '.') {
+            return $data;
+        }
+
+        $thousandSign = (string)($currency->thousand_sign ?? '');
+        if ($thousandSign === $decimalSign) {
+            $thousandSign = '';
+        }
+
+        $pattern = sprintf(
+            '/^-?(?:\d{1,3}(?:%s\d{3})+|\d+)%s\d+$/',
+            preg_quote($thousandSign, '/'),
+            preg_quote($decimalSign, '/'),
+        );
+
+        foreach ($rules as $key => $fieldRules) {
+            if (str_contains((string)$key, '*')) {
+                continue;
+            }
+
+            $fieldRules = is_array($fieldRules) ? $fieldRules : explode('|', (string)$fieldRules);
+            if (!in_array('numeric', $fieldRules, true)) {
+                continue;
+            }
+
+            $value = Arr::get($data, $key);
+            if (is_string($value) && preg_match($pattern, $value)) {
+                $value = $thousandSign === '' ? $value : str_replace($thousandSign, '', $value);
+                Arr::set($data, $key, str_replace($decimalSign, '.', $value));
+            }
+        }
+
+        return $data;
     }
 }

--- a/tests/src/System/Classes/FormRequestTest.php
+++ b/tests/src/System/Classes/FormRequestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Igniter\Tests\System\Classes;
 
 use Igniter\System\Classes\FormRequest;
+use Igniter\System\Models\Currency;
 use Illuminate\Validation\ValidationException;
 
 it('throws validation exception on failed validation', function() {
@@ -20,6 +21,74 @@ it('throws validation exception on failed validation', function() {
     };
 
     $formRequest->setContainer(app());
+
+    expect(fn() => $formRequest->validateResolved())->toThrow(ValidationException::class);
+});
+
+function currencyFormattedNumbersFormRequest(): FormRequest
+{
+    $formRequest = new class extends FormRequest
+    {
+        public function rules(): array
+        {
+            return [
+                'price' => ['required', 'numeric', 'min:0'],
+                'special.amount' => ['nullable', 'numeric'],
+                'name' => ['required', 'string'],
+            ];
+        }
+    };
+
+    $formRequest->setContainer(app());
+
+    return $formRequest;
+}
+
+it('accepts numeric input formatted with the default currency separators', function() {
+    Currency::factory()->create([
+        'decimal_sign' => ',',
+        'thousand_sign' => '.',
+    ])->makeDefault();
+    Currency::$defaultModels = [];
+
+    $formRequest = currencyFormattedNumbersFormRequest();
+    $formRequest->merge([
+        'price' => '11,50',
+        'special' => ['amount' => '1.234,56'],
+        'name' => 'a, b',
+    ]);
+
+    $formRequest->validateResolved();
+
+    expect($formRequest->validated()['price'])->toBe('11.50')
+        ->and($formRequest->validated()['special']['amount'])->toBe('1234.56')
+        ->and($formRequest->validated()['name'])->toBe('a, b');
+});
+
+it('leaves machine-format numeric input untouched under a comma-decimal currency', function() {
+    Currency::factory()->create([
+        'decimal_sign' => ',',
+        'thousand_sign' => '.',
+    ])->makeDefault();
+    Currency::$defaultModels = [];
+
+    $formRequest = currencyFormattedNumbersFormRequest();
+    $formRequest->merge(['price' => '11.50', 'name' => 'a']);
+
+    $formRequest->validateResolved();
+
+    expect($formRequest->validated()['price'])->toBe('11.50');
+});
+
+it('keeps rejecting comma decimals when the default currency uses a dot decimal sign', function() {
+    Currency::factory()->create([
+        'decimal_sign' => '.',
+        'thousand_sign' => ',',
+    ])->makeDefault();
+    Currency::$defaultModels = [];
+
+    $formRequest = currencyFormattedNumbersFormRequest();
+    $formRequest->merge(['price' => '11,50', 'name' => 'a']);
 
     expect(fn() => $formRequest->validateResolved())->toThrow(ValidationException::class);
 });


### PR DESCRIPTION
## The bug

`field_currency.blade.php` renders the field value using the default currency's decimal sign:

```blade
value="{{ number_format((float)$field->value, $decimalPosition, $decimalSign, '') }}"
```

On an install whose currency is configured with a comma decimal sign (e.g. EUR with `decimal_sign: ","`, `thousand_sign: "."` — the standard German format), the menu price field displays `11,50`. Saving the form then fails with "The price must be a number", because the `numeric` rule only accepts machine format. The same partial even declares `pattern="-?\d+(\.\d+)?"`, which the value it just rendered violates.

So on any non-dot-decimal install, **every currency field displays a value its own form refuses to save** — the admin has to manually retype prices with a dot on every edit, and gets a comma shown right back after saving.

## The fix

The system already has one configured truth for how numbers are written: the default currency's decimal/thousand signs — the same ones the field renders with. `FormRequest` now parses input **symmetrically**: values matching the configured currency format (`11,50`, `1.234,56`) are converted back to machine format for every explicitly `numeric`-validated (non-wildcard) field, before the validator is built — so both validation and `validated()` see the machine value.

- **No-op for default installs**: when the configured decimal sign is a dot, the method returns immediately — behavior is unchanged for every install that isn't currently broken.
- Machine-format input (`11.50`) keeps working on comma installs (it doesn't match the localized pattern and passes `numeric` as before).
- Interpretation is keyed to the install's own configuration, never guessed from the string, so `1,234` is only read as a decimal where the admin's currency says comma *is* the decimal sign.
- The partial's `pattern` attribute now also accepts the configured decimal sign.

## Tests

Three new cases in `FormRequestTest` (comma-install accepts+normalizes localized and nested values while leaving strings and machine format untouched; dot-install still rejects `11,50`). `tests/src/System`: 632 passed with this change vs. 629 on the unmodified baseline (+3 = the new tests; the same 16 pre-existing environment failures on both runs). Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)